### PR TITLE
Delete items not on watchlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,21 @@
 
 <img src="watchlistarr.png" alt="Alternate Text" width="240"/>
 
-Sync plex watchlists in realtime with Sonarr and Radarr. **Requires Plex Pass**
+Sync plex watchlists (yours and your friends) in realtime with Sonarr and Radarr. **Requires Plex Pass**
 
 ## Why?
+
 ### Sonarr/Radarr limitation
-While Sonarr and Radarr have built-in functionality (in v4 and v3 respectively), they are set at 6 hour refresh intervals, and cannot be customized
+
+While Sonarr and Radarr have built-in functionality (in v4 and v3 respectively), they are set at 6 hour refresh
+intervals, and cannot be customized
 
 ### Ombi/Overseer limitation
+
 While Ombi and Overseer have built-in functionality, there are two problems with this:
- * They are customizable down to 5 minute intervals, so doesn't allow the "real-time" sync that Watchlistarr does
- * They rely on Plex tokens, which expire and break the sync if you're not regularly logging into Ombi/Overseer
+
+* They are customizable down to 5 minute intervals, so doesn't allow the "real-time" sync that Watchlistarr does
+* They rely on Plex tokens, which expire and break the sync if you're not regularly logging into Ombi/Overseer
 
 ## Getting Started
 
@@ -26,25 +31,27 @@ docker run \
 ```
 
 Docker tag options:
- * `latest` - Stable version, follows the Releases
- * `beta` - Beta version, follows the main branch
- * `alpha` - Experimental version, follows the latest successful PR build
 
-| Key                      | Example Value                    | Optional | Description                                                              |
-|--------------------------|----------------------------------|----------|--------------------------------------------------------------------------|
-| REFRESH_INTERVAL_SECONDS | 60                               | Yes      | Number of seconds to wait in between checking the watchlist              |
-| SONARR_API_KEY           | 7a392fb4817a46e59f2e84e7d5f021bc | No       | API key for Sonarr, found in your Sonarr UI -> General settings          |
-| SONARR_BASE_URL          | http://localhost:8989            | Yes      | Base URL for Sonarr, including the 'http' and port                       |
-| SONARR_QUALITY_PROFILE   | 1080p                            | Yes      | Quality profile for Sonarr, found in your Sonarr UI -> Profiles settings |
-| SONARR_ROOT_FOLDER       | /data/                           | Yes      | Root folder for Sonarr                                                   |
-| SONARR_BYPASS_IGNORED    | true                             | Yes      | Boolean flag to bypass tv shows that are on the Sonarr Exclusion List    |
-| RADARR_API_KEY           | 7a392fb4817a46e59f2e84e7d5f021bc | No       | API key for Radarr, found in your Radarr UI -> General settings          |
-| RADARR_BASE_URL          | http://127.0.0.1:7878            | Yes      | Base URL for Radarr, including the 'http' and port                       |
-| RADARR_QUALITY_PROFILE   | 1080p                            | Yes      | Quality profile for Radarr, found in your Radarr UI -> Profiles settings |
-| RADARR_ROOT_FOLDER       | /data/                           | Yes      | Root folder for Radarr                                                   |
-| RADARR_BYPASS_IGNORED    | true                             | Yes      | Boolean flag to bypass movies that are on the Radarr Exclusion List      |
-| PLEX_WATCHLIST_URL_1     | https://rss.plex.tv/UUID         | No       | First Plex Watchlist URL                                                 |
-| PLEX_WATCHLIST_URL_2     | https://rss.plex.tv/UUID         | Yes      | Second Plex Watchlist URL (if applicable)                                |
+* `latest` - Stable version, follows the Releases
+* `beta` - Beta version, follows the main branch
+* `alpha` - Experimental version, follows the latest successful PR build
+
+| Key                      | Example Value                    | Optional | Description                                                                                                                                                                       |
+|--------------------------|----------------------------------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| SONARR_API_KEY           | 7a392fb4817a46e59f2e84e7d5f021bc | No       | API key for Sonarr, found in your Sonarr UI -> General settings                                                                                                                   |
+| RADARR_API_KEY           | 7a392fb4817a46e59f2e84e7d5f021bc | No       | API key for Radarr, found in your Radarr UI -> General settings                                                                                                                   |
+| PLEX_WATCHLIST_URL_1     | https://rss.plex.tv/UUID         | No       | First Plex Watchlist URL                                                                                                                                                          |
+| PLEX_WATCHLIST_URL_2     | https://rss.plex.tv/UUID         | Yes      | Second Plex Watchlist URL (if applicable)                                                                                                                                         |
+| REFRESH_INTERVAL_SECONDS | 60                               | Yes      | Number of seconds to wait in between checking the watchlist                                                                                                                       |
+| SONARR_BASE_URL          | http://localhost:8989            | Yes      | Base URL for Sonarr, including the 'http' and port                                                                                                                                |
+| SONARR_QUALITY_PROFILE   | 1080p                            | Yes      | Quality profile for Sonarr, found in your Sonarr UI -> Profiles settings                                                                                                          |
+| SONARR_ROOT_FOLDER       | /data/                           | Yes      | Root folder for Sonarr                                                                                                                                                            |
+| SONARR_BYPASS_IGNORED    | true                             | Yes      | Boolean flag to bypass tv shows that are on the Sonarr Exclusion List                                                                                                             |
+| RADARR_BASE_URL          | http://127.0.0.1:7878            | Yes      | Base URL for Radarr, including the 'http' and port                                                                                                                                |
+| RADARR_QUALITY_PROFILE   | 1080p                            | Yes      | Quality profile for Radarr, found in your Radarr UI -> Profiles settings                                                                                                          |
+| RADARR_ROOT_FOLDER       | /data/                           | Yes      | Root folder for Radarr                                                                                                                                                            |
+| RADARR_BYPASS_IGNORED    | true                             | Yes      | Boolean flag to bypass movies that are on the Radarr Exclusion List                                                                                                               |
+| PLEX_TOKEN               | YOUR_PLEX_TOKEN                  | Yes      | Your Plex Token (see [here](https://support.plex.tv/articles/204059436-finding-an-authentication-token-x-plex-token/) for how to get one). Only needed for advanced sync features |
 
 ### Getting your Plex Watchlist URLs
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -54,4 +54,8 @@ if [ -n "$RADARR_BYPASS_IGNORED" ]; then
   CMD="$CMD -Dradarr.bypassIgnored=$RADARR_BYPASS_IGNORED"
 fi
 
+if [ -n "$PLEX_TOKEN" ]; then
+  CMD="$CMD -Dplex.token=$PLEX_TOKEN"
+fi
+
 exec $CMD

--- a/src/main/scala/PlexToken.scala
+++ b/src/main/scala/PlexToken.scala
@@ -1,0 +1,158 @@
+import cats.effect.IO
+import configuration.Configuration
+import io.circe.Json
+import io.circe.syntax.EncoderOps
+import model._
+import cats.implicits._
+import org.http4s.{Method, Uri}
+import org.slf4j.LoggerFactory
+import io.circe.generic.auto._
+
+object PlexToken {
+
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  def ping(config: Configuration): IO[Unit] = config.plexToken.map { token =>
+    val url = Uri
+      .unsafeFromString("https://plex.tv/api/v2/ping")
+      .withQueryParam("X-Plex-Token", token)
+      .withQueryParam("X-Plex-Client-Identifier", "watchlistarr")
+
+    config.client.httpRequest(Method.GET, url).map {
+      case Right(_) =>
+        logger.info(s"Refreshed the access token expiry")
+      case Left(err) =>
+        logger.warn(s"Unable to ping plex.tv: $err")
+    }
+  }.getOrElse(IO.unit)
+
+  def getWatchlist(config: Configuration): IO[Unit] =
+    for {
+      selfWatchlist <- getSelfWatchlist(config)
+      friends <- getFriends(config)
+      watchlists <- getWatchlists(config)(friends)
+      movies <- WatchlistSync.fetchMovies(config.client)(apiKey = config.radarrApiKey, baseUrl = config.radarrBaseUrl, bypass = true)
+      shows <- WatchlistSync.fetchSeries(config.client)(apiKey = config.sonarrApiKey, baseUrl = config.sonarrBaseUrl, bypass = true)
+      allTitlesOnArr = movies.map(_.title) ++ shows.map(_.title)
+      allWatchlistTitles = (selfWatchlist ++ watchlists).map(_.title)
+      _ <- deleteContentNotOnWatchlist(allWatchlistTitles, allTitlesOnArr)
+    } yield ()
+
+  private def deleteContentNotOnWatchlist(watchlist: List[String], arrItems: List[String]): IO[Unit] = IO {
+    arrItems.foreach { maybeDeleteThis =>
+      if (!watchlist.contains(maybeDeleteThis)) {
+        logger.warn(s"DRY RUN: Deleting $maybeDeleteThis")
+      }
+    }
+
+    watchlist.foreach { wasThisIncluded =>
+      if (!arrItems.contains(wasThisIncluded)) {
+        logger.warn(s"Straggler: ${wasThisIncluded}")
+      }
+    }
+  }
+
+  private def getSelfWatchlist(config: Configuration): IO[List[Item]] =
+    config.plexToken.map { token =>
+      val url = Uri
+        .unsafeFromString("https://metadata.provider.plex.tv/library/sections/watchlist/all")
+        .withQueryParam("X-Plex-Token", token)
+
+      config.client.httpRequest(Method.GET, url).map {
+        case Right(result) =>
+          selfWatchlistToItems(result)
+        case Left(err) =>
+          logger.warn(s"Unable to query metadata.provider.plex.tv: $err")
+          List.empty
+      }
+    }.getOrElse(IO.pure(List.empty))
+
+  def selfWatchlistToItems(res: Json): List[Item] =
+    res.hcursor
+      .downField("MediaContainer")
+      .downField("Metadata")
+      .as[List[MetadataItem]]
+      .getOrElse(List.empty)
+      .map(_.toItem)
+
+  private def getFriends(config: Configuration): IO[List[User]] = config.plexToken.map { token =>
+    val url = Uri.unsafeFromString("https://community.plex.tv/api")
+
+    val query = GraphQLQuery(
+      """query GetAllFriends {
+        |        allFriendsV2 {
+        |          user {
+        |            id
+        |            username
+        |          }
+        |        }
+        |      }""".stripMargin)
+
+    config.client.httpRequest(Method.POST, url, Some(token), Some(query.asJson)).map {
+      case Right(res) =>
+        jsonToUserList(res)
+      case Left(err) =>
+        logger.warn(s"Unable to query plex.tv: $err")
+        List.empty
+    }
+  }.getOrElse(IO.pure(List.empty))
+
+  def jsonToUserList(res: Json): List[User] =
+    res.hcursor
+      .downField("data")
+      .downField("allFriendsV2")
+      .as[List[RootUser]]
+      .getOrElse(List.empty).map(_.user)
+
+  private def getWatchlists(config: Configuration)(users: List[User]): IO[List[Item]] = {
+    users.map { user =>
+      val url = Uri.unsafeFromString("https://community.plex.tv/api")
+      val query = GraphQLQuery(
+        """query GetWatchlistHub ($uuid: ID = "", $first: PaginationInt !, $after: String) {
+        user(id: $uuid) {
+          watchlist(first: $first, after: $after) {
+            nodes {
+            ...itemFields
+            }
+            pageInfo {
+              hasNextPage
+              endCursor
+            }
+          }
+        }
+      }
+
+        fragment itemFields on MetadataItem {
+        id
+        title
+        publicPagesURL
+        type
+      }""".stripMargin,
+        Some(
+          s"""{
+             |  "first": 100,
+             |  "uuid": "${user.id}"
+             |}""".stripMargin.asJson)
+      )
+
+      config.client.httpRequest(Method.POST, url, config.plexToken, Some(query.asJson)).map {
+        case Right(res) =>
+          jsonToItemList(res)
+        case Left(err) =>
+          logger.warn(s"Unable to query plex.tv: $err")
+          List.empty
+      }
+    }.sequence.map(_.flatten)
+  }
+
+  private def jsonToItemList(res: Json): List[Item] =
+    res.hcursor
+      .downField("data")
+      .downField("user")
+      .downField("watchlist")
+      .downField("nodes")
+      .as[List[GraphQLItem]]
+      .getOrElse(List.empty)
+      .map(_.toItem)
+
+}

--- a/src/main/scala/PlexToken.scala
+++ b/src/main/scala/PlexToken.scala
@@ -7,6 +7,7 @@ import cats.implicits._
 import org.http4s.{Method, Uri}
 import org.slf4j.LoggerFactory
 import io.circe.generic.auto._
+import utils.ArrUtils
 
 object PlexToken {
 
@@ -31,25 +32,84 @@ object PlexToken {
       selfWatchlist <- getSelfWatchlist(config)
       friends <- getFriends(config)
       watchlists <- getWatchlists(config)(friends)
-      movies <- WatchlistSync.fetchMovies(config.client)(apiKey = config.radarrApiKey, baseUrl = config.radarrBaseUrl, bypass = true)
-      shows <- WatchlistSync.fetchSeries(config.client)(apiKey = config.sonarrApiKey, baseUrl = config.sonarrBaseUrl, bypass = true)
-      allTitlesOnArr = movies.map(_.title) ++ shows.map(_.title)
-      allWatchlistTitles = (selfWatchlist ++ watchlists).map(_.title)
-      _ <- deleteContentNotOnWatchlist(allWatchlistTitles, allTitlesOnArr)
+      movies <- WatchlistSync.fetchMovies(config.client)(apiKey = config.radarrApiKey, baseUrl = config.radarrBaseUrl, bypass = config.radarrBypassIgnored)
+      shows <- WatchlistSync.fetchSeries(config.client)(apiKey = config.sonarrApiKey, baseUrl = config.sonarrBaseUrl, bypass = config.sonarrBypassIgnored)
+      allTitlesOnArr = moviesAndSeriesIntoItems(movies, shows)
+      allWatchlistTitles = selfWatchlist ++ watchlists
+      _ <- deleteContentNotOnWatchlist(config)(allWatchlistTitles, allTitlesOnArr)
     } yield ()
 
-  private def deleteContentNotOnWatchlist(watchlist: List[String], arrItems: List[String]): IO[Unit] = IO {
-    arrItems.foreach { maybeDeleteThis =>
-      if (!watchlist.contains(maybeDeleteThis)) {
-        logger.warn(s"DRY RUN: Deleting $maybeDeleteThis")
-      }
-    }
+  private def deleteContentNotOnWatchlist(config: Configuration)(watchlist: List[Item], arrItems: List[Item]): IO[Unit] = {
 
-    watchlist.foreach { wasThisIncluded =>
-      if (!arrItems.contains(wasThisIncluded)) {
-        logger.warn(s"Straggler: ${wasThisIncluded}")
+    logger.info(s"Beginning delete process, starting with ${watchlist.length} watchlist items and ${arrItems.length} -arrs")
+    logger.info(s"We look for the ones that have a watchlist entry but no arr entry, they need to be looked up")
+    val watchlistItemsToLookup = watchlist.map { w =>
+      if (!arrItems.map(_.title).contains(w.title)) {
+        logger.warn(s"Found watchlist entry to lookup: ${w.title}")
+        Some(w)
+      } else {
+        None
       }
+    }.collect { case Some(x) => x }
+
+    if (watchlistItemsToLookup.isEmpty) {
+      logger.info("No watchlist items remaining after comparing to -arr apps, we are ready for deletes")
+      IO.unit
+    } else {
+      val movies = watchlistItemsToLookup.filter(_.category == "movie")
+      logger.info(s"Movies: $movies")
+
+      movies
+        .map(i =>
+          existInRadarr(config)(i).map(r => (r, i))
+        )
+        .sequence
+        .map(_.filter(!_._1))
+        .map(r => logger.info(s"reamining: $r"))
     }
+  }
+
+  private def existInSonarr(config: Configuration)(item: Item): IO[Boolean] = {
+    val baseUrl = config.sonarrBaseUrl.withQueryParam("term", item.title)
+
+    ArrUtils.getToArr(config.client)(baseUrl, config.sonarrApiKey, "series/lookup").map {
+      case Right(res) =>
+        val result = res.as[List[SonarrSeries]].getOrElse {
+          logger.warn("Unable to fetch series from Sonarr")
+          List.empty
+        }.exists(_.path.nonEmpty)
+
+        logger.info(s"Does ${item.title} exist in sonarr? $result")
+        result
+      case Left(err) =>
+        logger.warn(s"Received error while trying to lookup ${item.title} in Sonarr: $err")
+        false
+    }
+  }
+
+  private def existInRadarr(config: Configuration)(item: Item): IO[Boolean] = {
+    val baseUrl = config.radarrBaseUrl.withQueryParam("term", item.title)
+
+    ArrUtils.getToArr(config.client)(baseUrl, config.radarrApiKey, "movie/lookup").map {
+      case Right(res) =>
+        val result = res.as[List[RadarrMovie]].getOrElse {
+          logger.warn("Unable to fetch series from Radarr")
+          List.empty
+        }.exists(_.path.nonEmpty)
+
+        logger.info(s"Does ${item.title} exist in radarr? $result")
+        result
+      case Left(err) =>
+        logger.warn(s"Received error while trying to lookup ${item.title} in Radarr: $err")
+        false
+    }
+  }
+
+  private def moviesAndSeriesIntoItems(movies: List[RadarrMovie], series: List[SonarrSeries]): List[Item] = {
+    val moviesItemized = movies.map(m => Item(m.title, List(m.imdbId, m.tmdbId.map(_.toString)).collect { case Some(r) => r }, "movie"))
+    val seriesItemized = series.map(s => Item(s.title, List(s.imdbId, s.tvdbId.map(_.toString)).collect { case Some(r) => r }, "show"))
+
+    moviesItemized ++ seriesItemized
   }
 
   private def getSelfWatchlist(config: Configuration): IO[List[Item]] =

--- a/src/main/scala/Server.scala
+++ b/src/main/scala/Server.scala
@@ -1,7 +1,10 @@
 
 import cats.effect._
+import cats.implicits.catsSyntaxTuple3Parallel
 import configuration.{Configuration, SystemPropertyReader}
 import utils.HttpClient
+
+import scala.concurrent.duration.DurationInt
 
 object Server extends IOApp {
   def run(args: List[String]): IO[ExitCode] = {
@@ -9,11 +12,22 @@ object Server extends IOApp {
     val httpClient = new HttpClient()
     val config = new Configuration(configReader, httpClient)(runtime)
 
-    def periodicTask: IO[Unit] =
+    def periodicRssSync: IO[Unit] =
       WatchlistSync.run(config) >>
         IO.sleep(config.refreshInterval) >>
-        periodicTask
+        periodicRssSync
 
-    periodicTask.foreverM.as(ExitCode.Success)
+    // We need to ping plex with the plex token once every 24 hours to renew the token expiry
+    def periodicPlexTokenPing: IO[Unit] =
+      PlexToken.ping(config) >>
+        IO.sleep(24.hours) >>
+        periodicPlexTokenPing
+
+    def periodicPlexTokenWatchlistSync: IO[Unit] =
+      PlexToken.getWatchlist(config) >>
+        IO.sleep(24.seconds) >>
+        periodicPlexTokenWatchlistSync
+
+    (periodicRssSync, periodicPlexTokenPing, periodicPlexTokenWatchlistSync).parTupled.as(ExitCode.Success)
   }
 }

--- a/src/main/scala/configuration/Configuration.scala
+++ b/src/main/scala/configuration/Configuration.scala
@@ -22,6 +22,7 @@ class Configuration(configReader: ConfigurationReader, val client: HttpClient)(i
   val (radarrBaseUrl, radarrApiKey, radarrQualityProfileId, radarrRootFolder) = getRadarrConfig.unsafeRunSync()
   val radarrBypassIgnored: Boolean = configReader.getConfigOption(Keys.radarrBypassIgnored).exists(_.toBoolean)
 
+  val plexToken: Option[String] = configReader.getConfigOption(Keys.plexToken)
   val plexWatchlistUrls: List[Uri] = getPlexWatchlistUrls
 
   private def getSonarrConfig: IO[(Uri, String, Int, String)] = {

--- a/src/main/scala/configuration/Keys.scala
+++ b/src/main/scala/configuration/Keys.scala
@@ -15,6 +15,7 @@ object Keys {
   val radarrRootFolder = "radarr.rootFolder"
   val radarrBypassIgnored = "radarr.bypassIgnored"
 
+  val plexToken = "plex.token"
   val plexWatchlist1 = "plex.watchlist1"
   val plexWatchlist2 = "plex.watchlist2"
 }

--- a/src/main/scala/model/GraphQLQuery.scala
+++ b/src/main/scala/model/GraphQLQuery.scala
@@ -1,0 +1,5 @@
+package model
+
+import io.circe.Json
+
+case class GraphQLQuery(query: String, variables: Option[Json] = None)

--- a/src/main/scala/model/Item.scala
+++ b/src/main/scala/model/Item.scala
@@ -1,3 +1,11 @@
 package model
 
 case class Item(title: String, guids: List[String], category: String)
+
+case class GraphQLItem(id: String, title: String, publicPagesURL: String, `type`: String) {
+  def toItem: Item = Item(this.title, List.empty, this.`type`.toLowerCase)
+}
+
+case class MetadataItem(title: String, `type`: String) {
+  def toItem: Item = Item(this.title, List.empty, this.`type`)
+}

--- a/src/main/scala/model/RadarrMovie.scala
+++ b/src/main/scala/model/RadarrMovie.scala
@@ -1,6 +1,6 @@
 package model
 
-case class RadarrMovie(title: String, imdbId: Option[String], tmdbId: Option[Long])
+case class RadarrMovie(title: String, imdbId: Option[String], tmdbId: Option[Long], path: Option[String] = None)
 
 case class RadarrMovieExclusion(movieTitle: String, imdbId: Option[String], tmdbId: Option[Long]) {
   def toRadarrMovie: RadarrMovie = RadarrMovie(this.movieTitle, this.imdbId, this.tmdbId)

--- a/src/main/scala/model/SonarrSeries.scala
+++ b/src/main/scala/model/SonarrSeries.scala
@@ -1,3 +1,3 @@
 package model
 
-case class SonarrSeries(title: String, imdbId: Option[String], tvdbId: Option[Long])
+case class SonarrSeries(title: String, imdbId: Option[String], tvdbId: Option[Long], path: Option[String])

--- a/src/main/scala/model/User.scala
+++ b/src/main/scala/model/User.scala
@@ -1,0 +1,5 @@
+package model
+
+case class RootUser(user: User)
+
+case class User(id: String, username: String)

--- a/src/main/scala/utils/HttpClient.scala
+++ b/src/main/scala/utils/HttpClient.scala
@@ -6,18 +6,33 @@ import org.http4s.{Header, Method, Request, Uri}
 import org.http4s.ember.client.EmberClientBuilder
 import org.typelevel.ci.CIString
 import org.http4s.circe._
-
-import scala.concurrent.duration.DurationInt
+import org.slf4j.LoggerFactory
 
 class HttpClient {
+  private val logger = LoggerFactory.getLogger(getClass)
   private val clientResource = EmberClientBuilder
     .default[IO]
     .build
 
-  def httpRequest(method: Method, url: Uri, apiKey: Option[String] = None, payload: Option[Json] = None): IO[Either[Throwable, Json]] = {
-    val baseRequest = Request[IO](method = method, uri = url).withHeaders(Header.Raw(CIString("Accept"), "application/json"))
-    val requestWithApiKey = apiKey.fold(baseRequest)(key => baseRequest.withHeaders(Header.Raw(CIString("X-Api-Key"), key)))
+  def httpRequest(
+                   method: Method,
+                   url: Uri,
+                   apiKey: Option[String] = None,
+                   payload: Option[Json] = None
+                 ): IO[Either[Throwable, Json]] = {
+    val baseRequest = Request[IO](method = method, uri = url)
+      .withHeaders(
+        Header.Raw(CIString("Accept"), "application/json"),
+        Header.Raw(CIString("Content-Type"), "application/json")
+      )
+    val requestWithApiKey = apiKey.fold(baseRequest)(key => baseRequest.withHeaders(
+      Header.Raw(CIString("X-Api-Key"), key),
+      Header.Raw(CIString("X-Plex-Token"), key),
+      baseRequest.headers
+    ))
     val requestWithPayload = payload.fold(requestWithApiKey)(p => requestWithApiKey.withEntity(p))
+
+    logger.debug(s"Requesting: $requestWithPayload")
 
     clientResource.use(_.expect[Json](requestWithPayload).attempt)
   }

--- a/src/test/resources/sonarr-search.json
+++ b/src/test/resources/sonarr-search.json
@@ -1,0 +1,475 @@
+[
+  {
+    "title": "One Piece",
+    "sortTitle": "one piece",
+    "status": "continuing",
+    "ended": false,
+    "overview": "The adventures of Monkey D. Luffy and his pirate crew in order to find the greatest treasure ever left by the legendary Pirate, Gold Roger. The famous mystery treasure named \"One Piece\".",
+    "network": "Fuji TV",
+    "airTime": "09:30",
+    "images": [
+      {
+        "coverType": "banner",
+        "url": "/MediaCover/75/banner.jpg?lastWrite=638329522687986232",
+        "remoteUrl": "https://artworks.thetvdb.com/banners/graphical/81797-g2.jpg"
+      },
+      {
+        "coverType": "poster",
+        "url": "/MediaCover/75/poster.jpg?lastWrite=638329522688516261",
+        "remoteUrl": "https://artworks.thetvdb.com/banners/series/81797/posters/5eec847d52a04.jpg"
+      },
+      {
+        "coverType": "fanart",
+        "url": "/MediaCover/75/fanart.jpg?lastWrite=638329522688816277",
+        "remoteUrl": "https://artworks.thetvdb.com/banners/v4/series/81797/backgrounds/616009a8bd688.jpg"
+      },
+      {
+        "coverType": "clearlogo",
+        "url": "/MediaCover/75/clearlogo.png?lastWrite=638329522689026289",
+        "remoteUrl": "https://artworks.thetvdb.com/banners/v4/series/81797/clearlogo/611b6189d88b6.png"
+      }
+    ],
+    "originalLanguage": {
+      "id": 8,
+      "name": "Japanese"
+    },
+    "remotePoster": "https://artworks.thetvdb.com/banners/series/81797/posters/5eec847d52a04.jpg",
+    "seasons": [
+      {
+        "seasonNumber": 0,
+        "monitored": false
+      },
+      {
+        "seasonNumber": 1,
+        "monitored": false
+      },
+      {
+        "seasonNumber": 2,
+        "monitored": false
+      },
+      {
+        "seasonNumber": 3,
+        "monitored": false
+      },
+      {
+        "seasonNumber": 4,
+        "monitored": false
+      },
+      {
+        "seasonNumber": 5,
+        "monitored": false
+      },
+      {
+        "seasonNumber": 6,
+        "monitored": false
+      },
+      {
+        "seasonNumber": 7,
+        "monitored": false
+      },
+      {
+        "seasonNumber": 8,
+        "monitored": false
+      },
+      {
+        "seasonNumber": 9,
+        "monitored": false
+      },
+      {
+        "seasonNumber": 10,
+        "monitored": false
+      },
+      {
+        "seasonNumber": 11,
+        "monitored": false
+      },
+      {
+        "seasonNumber": 12,
+        "monitored": false
+      },
+      {
+        "seasonNumber": 13,
+        "monitored": false
+      },
+      {
+        "seasonNumber": 14,
+        "monitored": false
+      },
+      {
+        "seasonNumber": 15,
+        "monitored": false
+      },
+      {
+        "seasonNumber": 16,
+        "monitored": false
+      },
+      {
+        "seasonNumber": 17,
+        "monitored": true
+      },
+      {
+        "seasonNumber": 18,
+        "monitored": true
+      },
+      {
+        "seasonNumber": 19,
+        "monitored": true
+      },
+      {
+        "seasonNumber": 20,
+        "monitored": true
+      },
+      {
+        "seasonNumber": 21,
+        "monitored": true
+      }
+    ],
+    "year": 1999,
+    "path": "/data/One Piece",
+    "qualityProfileId": 6,
+    "seasonFolder": true,
+    "monitored": true,
+    "useSceneNumbering": true,
+    "runtime": 25,
+    "tvdbId": 81797,
+    "tvRageId": 8205,
+    "tvMazeId": 1505,
+    "firstAired": "1999-10-20T00:00:00Z",
+    "seriesType": "anime",
+    "cleanTitle": "onepiece",
+    "imdbId": "tt0388629",
+    "titleSlug": "one-piece",
+    "folder": "One Piece",
+    "certification": "TV-Y7",
+    "genres": [
+      "Action",
+      "Adventure",
+      "Animation",
+      "Anime",
+      "Comedy",
+      "Drama",
+      "Fantasy"
+    ],
+    "tags": [],
+    "added": "2023-10-15T07:37:45Z",
+    "ratings": {
+      "votes": 0,
+      "value": 0
+    },
+    "statistics": {
+      "seasonCount": 21,
+      "episodeFileCount": 0,
+      "episodeCount": 0,
+      "totalEpisodeCount": 0,
+      "sizeOnDisk": 0,
+      "percentOfEpisodes": 0
+    },
+    "languageProfileId": 1,
+    "id": 75
+  },
+  {
+    "title": "ONE PIECE (2023)",
+    "sortTitle": "one piece 2023",
+    "status": "continuing",
+    "ended": false,
+    "overview": "With his straw hat and ragtag crew, young pirate Monkey D. Luffy goes on an epic voyage for treasure in this live-action adaptation of the popular manga.",
+    "network": "Netflix",
+    "airTime": "03:00",
+    "images": [
+      {
+        "coverType": "banner",
+        "url": "/MediaCover/83/banner.jpg?lastWrite=638338753517002207",
+        "remoteUrl": "https://artworks.thetvdb.com/banners/v4/series/392276/banners/64f03e2609d69.jpg"
+      },
+      {
+        "coverType": "poster",
+        "url": "/MediaCover/83/poster.jpg?lastWrite=638338753517142215",
+        "remoteUrl": "https://artworks.thetvdb.com/banners/v4/series/392276/posters/64c9042dd7d44.jpg"
+      },
+      {
+        "coverType": "fanart",
+        "url": "/MediaCover/83/fanart.jpg?lastWrite=638338753517412229",
+        "remoteUrl": "https://artworks.thetvdb.com/banners/v4/series/392276/backgrounds/64c113625ee67.jpg"
+      },
+      {
+        "coverType": "clearlogo",
+        "url": "/MediaCover/83/clearlogo.png?lastWrite=638338753517572238",
+        "remoteUrl": "https://artworks.thetvdb.com/banners/v4/series/392276/clearlogo/64c112a3357ce.png"
+      }
+    ],
+    "originalLanguage": {
+      "id": 1,
+      "name": "English"
+    },
+    "remotePoster": "https://artworks.thetvdb.com/banners/v4/series/392276/posters/64c9042dd7d44.jpg",
+    "seasons": [
+      {
+        "seasonNumber": 0,
+        "monitored": false
+      },
+      {
+        "seasonNumber": 1,
+        "monitored": true
+      }
+    ],
+    "year": 2023,
+    "path": "/data/ONE PIECE (2023)",
+    "qualityProfileId": 6,
+    "seasonFolder": false,
+    "monitored": true,
+    "useSceneNumbering": false,
+    "runtime": 57,
+    "tvdbId": 392276,
+    "tvRageId": 0,
+    "tvMazeId": 46065,
+    "firstAired": "2023-08-31T00:00:00Z",
+    "seriesType": "standard",
+    "cleanTitle": "onepiece2023",
+    "imdbId": "tt11737520",
+    "titleSlug": "one-piece-2023",
+    "folder": "ONE PIECE (2023)",
+    "certification": "TV-14",
+    "genres": [
+      "Action",
+      "Adventure",
+      "Drama",
+      "Fantasy"
+    ],
+    "tags": [],
+    "added": "2023-10-26T00:02:31Z",
+    "ratings": {
+      "votes": 0,
+      "value": 0
+    },
+    "statistics": {
+      "seasonCount": 1,
+      "episodeFileCount": 0,
+      "episodeCount": 0,
+      "totalEpisodeCount": 0,
+      "sizeOnDisk": 0,
+      "percentOfEpisodes": 0
+    },
+    "languageProfileId": 1,
+    "id": 83
+  },
+  {
+    "title": "One Piece D&D",
+    "sortTitle": "one piece dd",
+    "status": "ended",
+    "ended": true,
+    "overview": "One Piece D&D is produced and streamed by\u00A0Rustage, it is a D&D inspired One Piece Adventure streamed on his\u00A0twitch\u00A0and uploaded to his\u00A0second channel, it stars four anime YouTube personalities!\r\nWilliam, played by\u00A0Tekking101 - Duros, played by\u00A0Lost Pause - Verona, played by\u00A02Spooky - Ragnar, played by\u00A0All Day",
+    "airTime": "00:00",
+    "images": [],
+    "originalLanguage": {
+      "id": 1,
+      "name": "English"
+    },
+    "seasons": [
+      {
+        "seasonNumber": 1,
+        "monitored": true
+      }
+    ],
+    "year": 2020,
+    "qualityProfileId": 0,
+    "seasonFolder": false,
+    "monitored": true,
+    "useSceneNumbering": false,
+    "runtime": 0,
+    "tvdbId": 424413,
+    "tvRageId": 0,
+    "tvMazeId": 0,
+    "firstAired": "2020-04-12T00:00:00Z",
+    "seriesType": "standard",
+    "cleanTitle": "onepiecedd",
+    "imdbId": "tt16788668",
+    "titleSlug": "one-piece-dandd",
+    "folder": "One Piece D&D",
+    "genres": [
+      "Action",
+      "Adventure",
+      "Fantasy",
+      "Podcast"
+    ],
+    "tags": [],
+    "added": "0001-01-01T00:00:00Z",
+    "ratings": {
+      "votes": 0,
+      "value": 0
+    },
+    "statistics": {
+      "seasonCount": 1,
+      "episodeFileCount": 0,
+      "episodeCount": 0,
+      "totalEpisodeCount": 0,
+      "sizeOnDisk": 0,
+      "percentOfEpisodes": 0
+    },
+    "languageProfileId": 1
+  },
+  {
+    "title": "Cursed One-Piece",
+    "sortTitle": "cursed onepiece",
+    "status": "ended",
+    "ended": true,
+    "overview": "An omnibus horror that unfolds the story of three girls around a floral dress,  that causes strange events to happen to those who wear it.",
+    "airTime": "00:00",
+    "images": [
+      {
+        "coverType": "poster",
+        "url": "/MediaCoverProxy/8baeda89917685ab159dc48b720d5578e8a43d4550996004f5f0dd1dbf85ef42/630e4a4044f7c.jpg",
+        "remoteUrl": "https://artworks.thetvdb.com/banners/v4/series/422877/posters/630e4a4044f7c.jpg"
+      }
+    ],
+    "originalLanguage": {
+      "id": 8,
+      "name": "Japanese"
+    },
+    "remotePoster": "https://artworks.thetvdb.com/banners/v4/series/422877/posters/630e4a4044f7c.jpg",
+    "seasons": [
+      {
+        "seasonNumber": 1,
+        "monitored": true
+      }
+    ],
+    "year": 1992,
+    "qualityProfileId": 0,
+    "seasonFolder": false,
+    "monitored": true,
+    "useSceneNumbering": false,
+    "runtime": 8,
+    "tvdbId": 422877,
+    "tvRageId": 0,
+    "tvMazeId": 0,
+    "firstAired": "1992-08-25T00:00:00Z",
+    "seriesType": "standard",
+    "cleanTitle": "cursedonepiece",
+    "titleSlug": "cursed-one-piece",
+    "folder": "Cursed One-Piece",
+    "genres": [
+      "Horror",
+      "Romance"
+    ],
+    "tags": [],
+    "added": "0001-01-01T00:00:00Z",
+    "ratings": {
+      "votes": 0,
+      "value": 0
+    },
+    "statistics": {
+      "seasonCount": 1,
+      "episodeFileCount": 0,
+      "episodeCount": 0,
+      "totalEpisodeCount": 0,
+      "sizeOnDisk": 0,
+      "percentOfEpisodes": 0
+    },
+    "languageProfileId": 1
+  },
+  {
+    "title": "WE ARE ONE.",
+    "sortTitle": "we are one",
+    "status": "ended",
+    "ended": true,
+    "overview": "This work is a short drama of 5 episodes directed by Mika Ninagawa. Director Nagikawa, who is famous for his colorful video works, challenged an unprecedented video composition in which the live-action part, which is directed by the cast of gorgeous actors, and the new animation part produced by Toei Animation are interlaced. With the sprinting feeling and vitality sound of RADWIMPS's theme song \"TWILIGHT\" as the background, the charm of \"ONE PIECE\" is drawn from a new perspective and world view.",
+    "network": "YouTube",
+    "airTime": "00:00",
+    "images": [
+      {
+        "coverType": "fanart",
+        "url": "/MediaCoverProxy/5f9eda3d09c21894bdfcb254d702cdd8c7bf2457f44a18214191b220fe9acbba/6132665ccf556.jpg",
+        "remoteUrl": "https://artworks.thetvdb.com/banners/v4/series/409531/backgrounds/6132665ccf556.jpg"
+      }
+    ],
+    "originalLanguage": {
+      "id": 8,
+      "name": "Japanese"
+    },
+    "seasons": [
+      {
+        "seasonNumber": 1,
+        "monitored": true
+      }
+    ],
+    "year": 2021,
+    "qualityProfileId": 0,
+    "seasonFolder": false,
+    "monitored": true,
+    "useSceneNumbering": false,
+    "runtime": 9,
+    "tvdbId": 409531,
+    "tvRageId": 0,
+    "tvMazeId": 0,
+    "firstAired": "2021-08-30T00:00:00Z",
+    "seriesType": "standard",
+    "cleanTitle": "weareone",
+    "titleSlug": "we-are-one",
+    "folder": "WE ARE ONE",
+    "genres": [
+      "Anime",
+      "Drama"
+    ],
+    "tags": [],
+    "added": "0001-01-01T00:00:00Z",
+    "ratings": {
+      "votes": 0,
+      "value": 0
+    },
+    "statistics": {
+      "seasonCount": 1,
+      "episodeFileCount": 0,
+      "episodeCount": 0,
+      "totalEpisodeCount": 0,
+      "sizeOnDisk": 0,
+      "percentOfEpisodes": 0
+    },
+    "languageProfileId": 1
+  },
+  {
+    "title": "Insight for Living on OnePlace.com",
+    "sortTitle": "insight for living on oneplacecom",
+    "status": "upcoming",
+    "ended": false,
+    "overview": "Insight for Living is the Bible-teaching ministry of author and pastor Charles R. Swindoll. Insight for Living is committed to excellence in communicating biblical truth and its application.",
+    "airTime": "00:00",
+    "images": [],
+    "originalLanguage": {
+      "id": 1,
+      "name": "English"
+    },
+    "seasons": [],
+    "year": 0,
+    "qualityProfileId": 0,
+    "seasonFolder": false,
+    "monitored": true,
+    "useSceneNumbering": false,
+    "runtime": 0,
+    "tvdbId": 433352,
+    "tvRageId": 0,
+    "tvMazeId": 0,
+    "seriesType": "standard",
+    "cleanTitle": "insightforlivingononeplacecom",
+    "imdbId": "tt24550314",
+    "titleSlug": "insight-for-living-on-oneplacecom",
+    "folder": "Insight for Living on OnePlace.com",
+    "genres": [
+      "Documentary",
+      "Family"
+    ],
+    "tags": [],
+    "added": "0001-01-01T00:00:00Z",
+    "ratings": {
+      "votes": 0,
+      "value": 0
+    },
+    "statistics": {
+      "seasonCount": 0,
+      "episodeFileCount": 0,
+      "episodeCount": 0,
+      "totalEpisodeCount": 0,
+      "sizeOnDisk": 0,
+      "percentOfEpisodes": 0
+    },
+    "languageProfileId": 1
+  }
+]

--- a/src/test/resources/users.json
+++ b/src/test/resources/users.json
@@ -1,0 +1,24 @@
+{
+  "data" : {
+    "allFriendsV2" : [
+      {
+        "user" : {
+          "id" : "12345",
+          "username" : "nylonee1"
+        }
+      },
+      {
+        "user" : {
+          "id" : "67890",
+          "username" : "nylonee2"
+        }
+      },
+      {
+        "user" : {
+          "id" : "45678",
+          "username" : "nylonee3"
+        }
+      }
+    ]
+  }
+}

--- a/src/test/resources/watchlist-from-token.json
+++ b/src/test/resources/watchlist-from-token.json
@@ -1,0 +1,664 @@
+{
+  "MediaContainer" : {
+    "librarySectionID" : "watchlist",
+    "librarySectionTitle" : "Watchlist",
+    "offset" : 0,
+    "totalSize" : 11,
+    "identifier" : "tv.plex.provider.metadata",
+    "size" : 11,
+    "Metadata" : [
+      {
+        "art" : "https://image.tmdb.org/t/p/original/irv4GNEi7d2yN0XL1ZpwJCH9Qpz.jpg",
+        "banner" : "https://artworks.thetvdb.com/banners/v4/series/372848/banners/62fd2b381d5f3.jpg",
+        "guid" : "plex://show/5df46a38237002001dce338d",
+        "key" : "/library/metadata/5df46a38237002001dce338d/children",
+        "rating" : 8.8,
+        "ratingKey" : "5df46a38237002001dce338d",
+        "studio" : "CA Film",
+        "tagline" : "A New Era for Australia's Team",
+        "type" : "show",
+        "thumb" : "https://image.tmdb.org/t/p/original/mIDaHnJPeMGKDSR76L73BURLOv7.jpg",
+        "addedAt" : 1583884800,
+        "duration" : 2580000,
+        "publicPagesURL" : "https://watch.plex.tv/show/the-test-a-new-era-for-australias-team",
+        "slug" : "the-test-a-new-era-for-australias-team",
+        "userState" : false,
+        "title" : "The Test",
+        "leafCount" : 12,
+        "childCount" : 2,
+        "isContinuingSeries" : true,
+        "contentRating" : "TV-14",
+        "originallyAvailableAt" : "2020-03-11",
+        "year" : 2020,
+        "ratingImage" : "imdb://image.rating",
+        "imdbRatingCount" : 3455,
+        "Image" : [
+          {
+            "alt" : "The Test",
+            "type" : "background",
+            "url" : "https://image.tmdb.org/t/p/original/irv4GNEi7d2yN0XL1ZpwJCH9Qpz.jpg"
+          },
+          {
+            "alt" : "The Test",
+            "type" : "banner",
+            "url" : "https://artworks.thetvdb.com/banners/v4/series/372848/banners/62fd2b381d5f3.jpg"
+          },
+          {
+            "alt" : "The Test",
+            "type" : "coverArt",
+            "url" : "https://metadata-static.plex.tv/a/gracenote/aaa03c4a33fedc650e9f882e62834bb6.jpg"
+          },
+          {
+            "alt" : "The Test",
+            "type" : "coverPoster",
+            "url" : "https://image.tmdb.org/t/p/original/mIDaHnJPeMGKDSR76L73BURLOv7.jpg"
+          },
+          {
+            "alt" : "The Test",
+            "type" : "coverSquare",
+            "url" : "https://metadata-static.plex.tv/0/gracenote/003496a06f7738c98a32f947b6926914.jpg"
+          }
+        ]
+      },
+      {
+        "art" : "https://image.tmdb.org/t/p/original/xvzxqKWltnj6qSiWBXRq6ZCdcrw.jpg",
+        "banner" : "http://assets.fanart.tv/fanart/movies/1151534/moviebanner/nowhere-652724e79f726.jpg",
+        "guid" : "plex://movie/617d3ab142705b2183b1b20b",
+        "key" : "/library/metadata/617d3ab142705b2183b1b20b",
+        "primaryExtraKey" : "/library/metadata/617d3ab142705b2183b1b20b/extras/6504ffbc6859cd3ba9adb619",
+        "rating" : 6.2,
+        "ratingKey" : "617d3ab142705b2183b1b20b",
+        "studio" : "Rock & Ruz",
+        "tagline" : "Attempting to survive in the middle of nowhere is her only option.",
+        "type" : "movie",
+        "thumb" : "https://image.tmdb.org/t/p/original/zwKaPkkLizCg1onpHQq89LWugkS.jpg",
+        "addedAt" : 1695945600,
+        "duration" : 6540000,
+        "publicPagesURL" : "https://watch.plex.tv/movie/nowhere-17",
+        "slug" : "nowhere-17",
+        "userState" : false,
+        "title" : "Nowhere",
+        "contentRating" : "R",
+        "originallyAvailableAt" : "2023-09-29",
+        "year" : 2023,
+        "audienceRating" : 6.2,
+        "audienceRatingImage" : "rottentomatoes://image.rating.upright",
+        "ratingImage" : "rottentomatoes://image.rating.ripe",
+        "imdbRatingCount" : 22485,
+        "Image" : [
+          {
+            "alt" : "Nowhere",
+            "type" : "background",
+            "url" : "https://image.tmdb.org/t/p/original/xvzxqKWltnj6qSiWBXRq6ZCdcrw.jpg"
+          },
+          {
+            "alt" : "Nowhere",
+            "type" : "banner",
+            "url" : "http://assets.fanart.tv/fanart/movies/1151534/moviebanner/nowhere-652724e79f726.jpg"
+          },
+          {
+            "alt" : "Nowhere",
+            "type" : "clearLogoWide",
+            "url" : "http://assets.fanart.tv/fanart/movies/1151534/hdmovielogo/nowhere-651b207542604.png"
+          },
+          {
+            "alt" : "Nowhere",
+            "type" : "coverArt",
+            "url" : "https://metadata-static.plex.tv/8/gracenote/895c9c368de4e83c752791eaa362b96d.jpg"
+          },
+          {
+            "alt" : "Nowhere",
+            "type" : "coverPoster",
+            "url" : "https://image.tmdb.org/t/p/original/zwKaPkkLizCg1onpHQq89LWugkS.jpg"
+          },
+          {
+            "alt" : "Nowhere",
+            "type" : "coverSquare",
+            "url" : "https://metadata-static.plex.tv/d/gracenote/d26f1f2c7ff370a7c27345248c3e6888.jpg"
+          },
+          {
+            "alt" : "Nowhere",
+            "type" : "snapshot",
+            "url" : "https://metadata-static.plex.tv/2/gracenote/29bdff575ed2ac00d7e86c75a7d6c943.jpg"
+          }
+        ]
+      },
+      {
+        "art" : "https://image.tmdb.org/t/p/original/H6j5smdpRqP9a8UnhWp6zfl0SC.jpg",
+        "banner" : "https://artworks.thetvdb.com/banners/v4/movie/156176/banners/648663a3e9004.jpg",
+        "guid" : "plex://movie/5d7770a5fb0d55001f5f59bb",
+        "key" : "/library/metadata/5d7770a5fb0d55001f5f59bb",
+        "primaryExtraKey" : "/library/metadata/5d7770a5fb0d55001f5f59bb/extras/642cb5c7028daf065e96db46",
+        "rating" : 7.8,
+        "ratingKey" : "5d7770a5fb0d55001f5f59bb",
+        "studio" : "Warner Bros. Pictures",
+        "tagline" : "Jaime Reyes is a superhero whether he likes it or not.",
+        "type" : "movie",
+        "thumb" : "https://image.tmdb.org/t/p/original/vNfL4DYnonltukBrrgMmw94zMYL.jpg",
+        "addedAt" : 1692144000,
+        "duration" : 7620000,
+        "publicPagesURL" : "https://watch.plex.tv/movie/blue-beetle",
+        "slug" : "blue-beetle",
+        "userState" : false,
+        "title" : "Blue Beetle",
+        "contentRating" : "PG-13",
+        "originallyAvailableAt" : "2023-08-16",
+        "year" : 2023,
+        "audienceRating" : 9.2,
+        "audienceRatingImage" : "rottentomatoes://image.rating.upright",
+        "ratingImage" : "rottentomatoes://image.rating.ripe",
+        "imdbRatingCount" : 56556,
+        "Image" : [
+          {
+            "alt" : "Blue Beetle",
+            "type" : "background",
+            "url" : "https://image.tmdb.org/t/p/original/H6j5smdpRqP9a8UnhWp6zfl0SC.jpg"
+          },
+          {
+            "alt" : "Blue Beetle",
+            "type" : "banner",
+            "url" : "https://artworks.thetvdb.com/banners/v4/movie/156176/banners/648663a3e9004.jpg"
+          },
+          {
+            "alt" : "Blue Beetle",
+            "type" : "clearLogoWide",
+            "url" : "http://assets.fanart.tv/fanart/movies/565770/hdmovielogo/blue-beetle-642c73f81cd09.png"
+          },
+          {
+            "alt" : "Blue Beetle",
+            "type" : "coverArt",
+            "url" : "https://metadata-static.plex.tv/b/gracenote/b8d42f4943815f35afb363e081f5810d.jpg"
+          },
+          {
+            "alt" : "Blue Beetle",
+            "type" : "coverPoster",
+            "url" : "https://image.tmdb.org/t/p/original/vNfL4DYnonltukBrrgMmw94zMYL.jpg"
+          },
+          {
+            "alt" : "Blue Beetle",
+            "type" : "coverSquare",
+            "url" : "https://metadata-static.plex.tv/e/gracenote/ef4015dce5168c88deb20c5caa5e91ed.jpg"
+          },
+          {
+            "alt" : "Blue Beetle",
+            "type" : "snapshot",
+            "url" : "https://metadata-static.plex.tv/9/gracenote/9143aec36913e6736eb468fc11d143ca.jpg"
+          }
+        ]
+      },
+      {
+        "art" : "https://image.tmdb.org/t/p/original/aRKQdF6AGbhnF9IAyJbte5epH5R.jpg",
+        "banner" : "https://artworks.thetvdb.com/banners/v4/series/392276/banners/64f03e2609d69.jpg",
+        "guid" : "plex://show/5f7c9b1c9b958e00415de6bb",
+        "key" : "/library/metadata/5f7c9b1c9b958e00415de6bb/children",
+        "primaryExtraKey" : "/library/metadata/5f7c9b1c9b958e00415de6bb/extras/64bc79b0d10f4a2f43a2573b",
+        "rating" : 8.4,
+        "ratingKey" : "5f7c9b1c9b958e00415de6bb",
+        "studio" : "Tomorrow Studios",
+        "tagline" : "Come on board and bring along all your hopes and dreams",
+        "type" : "show",
+        "thumb" : "https://image.tmdb.org/t/p/original/rVX05xRKS5JhEYQFObCi4lAnZT4.jpg",
+        "addedAt" : 1693440000,
+        "duration" : 3600000,
+        "publicPagesURL" : "https://watch.plex.tv/show/one-piece-2",
+        "slug" : "one-piece-2",
+        "userState" : false,
+        "title" : "ONE PIECE (2023)",
+        "leafCount" : 8,
+        "childCount" : 1,
+        "isContinuingSeries" : true,
+        "contentRating" : "TV-14",
+        "originallyAvailableAt" : "2023-08-31",
+        "year" : 2023,
+        "ratingImage" : "imdb://image.rating",
+        "imdbRatingCount" : 116606,
+        "Image" : [
+          {
+            "alt" : "ONE PIECE (2023)",
+            "type" : "background",
+            "url" : "https://image.tmdb.org/t/p/original/aRKQdF6AGbhnF9IAyJbte5epH5R.jpg"
+          },
+          {
+            "alt" : "ONE PIECE (2023)",
+            "type" : "banner",
+            "url" : "https://artworks.thetvdb.com/banners/v4/series/392276/banners/64f03e2609d69.jpg"
+          },
+          {
+            "alt" : "ONE PIECE (2023)",
+            "type" : "clearLogoWide",
+            "url" : "http://assets.fanart.tv/fanart/tv/392276/hdtvlogo/one-piece-2022-641b9f7b3aff6.png"
+          },
+          {
+            "alt" : "ONE PIECE (2023)",
+            "type" : "coverArt",
+            "url" : "https://metadata-static.plex.tv/d/gracenote/dffd81ea6bdf25c71b06453bc81b4d2d.jpg"
+          },
+          {
+            "alt" : "ONE PIECE (2023)",
+            "type" : "coverPoster",
+            "url" : "https://image.tmdb.org/t/p/original/yEtSBgugED8XyhqjcKgF6j2zDMf.jpg"
+          },
+          {
+            "alt" : "ONE PIECE (2023)",
+            "type" : "coverSquare",
+            "url" : "https://metadata-static.plex.tv/c/gracenote/caec1f4bcef1a18f07ca2954deeb2afa.jpg"
+          }
+        ]
+      },
+      {
+        "art" : "https://image.tmdb.org/t/p/original/3JCR5pQgCniNpflq47BqBVAKKyN.jpg",
+        "guid" : "plex://movie/5d7770b2594b2b001e74fb7e",
+        "key" : "/library/metadata/5d7770b2594b2b001e74fb7e",
+        "primaryExtraKey" : "/library/metadata/5d7770b2594b2b001e74fb7e/extras/6503594ab447237c92e7523c",
+        "ratingKey" : "5d7770b2594b2b001e74fb7e",
+        "studio" : "Warner Bros. Pictures",
+        "tagline" : "The tide is turning.",
+        "type" : "movie",
+        "thumb" : "https://image.tmdb.org/t/p/original/vCbguyLsg3wJt2rdMMFfJ5zacr1.jpg",
+        "addedAt" : 1702512000,
+        "duration" : 6900000,
+        "publicPagesURL" : "https://watch.plex.tv/movie/aquaman-2",
+        "slug" : "aquaman-2",
+        "userState" : false,
+        "title" : "Aquaman and the Lost Kingdom",
+        "contentRating" : "PG-13",
+        "originallyAvailableAt" : "2023-12-14",
+        "year" : 2023,
+        "Image" : [
+          {
+            "alt" : "Aquaman and the Lost Kingdom",
+            "type" : "background",
+            "url" : "https://image.tmdb.org/t/p/original/3JCR5pQgCniNpflq47BqBVAKKyN.jpg"
+          },
+          {
+            "alt" : "Aquaman and the Lost Kingdom",
+            "type" : "clearLogoWide",
+            "url" : "http://assets.fanart.tv/fanart/movies/572802/hdmovielogo/aquaman-and-the-lost-kingdom-62360561890c4.png"
+          },
+          {
+            "alt" : "Aquaman and the Lost Kingdom",
+            "type" : "coverArt",
+            "url" : "https://metadata-static.plex.tv/8/gracenote/823b54ed641c11074996ede69dcf899d.jpg"
+          },
+          {
+            "alt" : "Aquaman and the Lost Kingdom",
+            "type" : "coverPoster",
+            "url" : "https://image.tmdb.org/t/p/original/vCbguyLsg3wJt2rdMMFfJ5zacr1.jpg"
+          },
+          {
+            "alt" : "Aquaman and the Lost Kingdom",
+            "type" : "coverSquare",
+            "url" : "https://metadata-static.plex.tv/3/gracenote/37168660371f8391e05b14a546ab4523.jpg"
+          },
+          {
+            "alt" : "Aquaman and the Lost Kingdom",
+            "type" : "snapshot",
+            "url" : "https://metadata-static.plex.tv/f/gracenote/f64a4fd8cb5cdcea9f342f32da3b5e3d.jpg"
+          }
+        ]
+      },
+      {
+        "art" : "https://image.tmdb.org/t/p/original/rron9HAuS9s7zBF8iCX1tsafxUo.jpg",
+        "banner" : "http://assets.fanart.tv/fanart/movies/666277/moviebanner/past-lives-64e78291b2bcc.jpg",
+        "guid" : "plex://movie/5f86722f2556d100412f614d",
+        "key" : "/library/metadata/5f86722f2556d100412f614d",
+        "primaryExtraKey" : "/library/metadata/5f86722f2556d100412f614d/extras/63f6c7bdc101700cb341f93a",
+        "rating" : 9.8,
+        "ratingKey" : "5f86722f2556d100412f614d",
+        "studio" : "A24",
+        "tagline" : "What a good story this is.",
+        "type" : "movie",
+        "thumb" : "https://image.tmdb.org/t/p/original/rzO71VFu7CpJMfF5TQNMj0d1lSV.jpg",
+        "addedAt" : 1685664000,
+        "duration" : 6300000,
+        "publicPagesURL" : "https://watch.plex.tv/movie/past-lives-3",
+        "slug" : "past-lives-3",
+        "userState" : false,
+        "title" : "Past Lives",
+        "contentRating" : "PG-13",
+        "originallyAvailableAt" : "2023-06-02",
+        "year" : 2023,
+        "audienceRating" : 9.2,
+        "audienceRatingImage" : "rottentomatoes://image.rating.upright",
+        "ratingImage" : "rottentomatoes://image.rating.ripe",
+        "imdbRatingCount" : 35630,
+        "Image" : [
+          {
+            "alt" : "Past Lives",
+            "type" : "background",
+            "url" : "https://image.tmdb.org/t/p/original/rron9HAuS9s7zBF8iCX1tsafxUo.jpg"
+          },
+          {
+            "alt" : "Past Lives",
+            "type" : "banner",
+            "url" : "http://assets.fanart.tv/fanart/movies/666277/moviebanner/past-lives-64e78291b2bcc.jpg"
+          },
+          {
+            "alt" : "Past Lives",
+            "type" : "clearLogoWide",
+            "url" : "http://assets.fanart.tv/fanart/movies/666277/hdmovielogo/past-lives-642b07e00a28e.png"
+          },
+          {
+            "alt" : "Past Lives",
+            "type" : "coverArt",
+            "url" : "https://metadata-static.plex.tv/4/gracenote/43f956985cf12b2d07733b74f159a2a5.jpg"
+          },
+          {
+            "alt" : "Past Lives",
+            "type" : "coverPoster",
+            "url" : "https://image.tmdb.org/t/p/original/rzO71VFu7CpJMfF5TQNMj0d1lSV.jpg"
+          },
+          {
+            "alt" : "Past Lives",
+            "type" : "coverSquare",
+            "url" : "https://metadata-static.plex.tv/0/gracenote/0a1ac0ca4802104d7d540736c7eaf3b4.jpg"
+          },
+          {
+            "alt" : "Past Lives",
+            "type" : "snapshot",
+            "url" : "https://metadata-static.plex.tv/0/gracenote/04afa409f2075d3e226c95bc20ddb2d8.jpg"
+          }
+        ]
+      },
+      {
+        "art" : "https://image.tmdb.org/t/p/original/x9tsSyltV2N814LtABb41NjVMd7.jpg",
+        "banner" : "https://artworks.thetvdb.com/banners/v4/movie/349541/banners/6514ede129282.jpg",
+        "guid" : "plex://movie/64ce38a43c64e3111391ee9d",
+        "key" : "/library/metadata/64ce38a43c64e3111391ee9d",
+        "primaryExtraKey" : "/library/metadata/64ce38a43c64e3111391ee9d/extras/64f2081572f51dc063409b08",
+        "rating" : 9.9,
+        "ratingKey" : "64ce38a43c64e3111391ee9d",
+        "studio" : "Taylor Swift Productions",
+        "tagline" : "It’s been a long time coming.",
+        "type" : "movie",
+        "thumb" : "https://image.tmdb.org/t/p/original/a5EreVlyB9fXzZ2Rf9ugOLrW5YI.jpg",
+        "addedAt" : 1697068800,
+        "duration" : 10140000,
+        "publicPagesURL" : "https://watch.plex.tv/movie/taylor-swift-the-eras-tour-movie",
+        "slug" : "taylor-swift-the-eras-tour-movie",
+        "userState" : false,
+        "title" : "Taylor Swift: The Eras Tour",
+        "contentRating" : "PG-13",
+        "originallyAvailableAt" : "2023-10-12",
+        "year" : 2023,
+        "audienceRating" : 9.8,
+        "audienceRatingImage" : "rottentomatoes://image.rating.upright",
+        "ratingImage" : "rottentomatoes://image.rating.ripe",
+        "imdbRatingCount" : 9165,
+        "Image" : [
+          {
+            "alt" : "Taylor Swift: The Eras Tour",
+            "type" : "background",
+            "url" : "https://image.tmdb.org/t/p/original/x9tsSyltV2N814LtABb41NjVMd7.jpg"
+          },
+          {
+            "alt" : "Taylor Swift: The Eras Tour",
+            "type" : "banner",
+            "url" : "https://artworks.thetvdb.com/banners/v4/movie/349541/banners/6514ede129282.jpg"
+          },
+          {
+            "alt" : "Taylor Swift: The Eras Tour",
+            "type" : "clearLogoWide",
+            "url" : "http://assets.fanart.tv/fanart/movies/1160164/hdmovielogo/taylor-swift--the-eras-tour-650c6d342cc84.png"
+          },
+          {
+            "alt" : "Taylor Swift: The Eras Tour",
+            "type" : "coverArt",
+            "url" : "https://image.tmdb.org/t/p/original/A5yngqjWsUggUZHDc60I3O5nmNu.jpg"
+          },
+          {
+            "alt" : "Taylor Swift: The Eras Tour",
+            "type" : "coverPoster",
+            "url" : "https://image.tmdb.org/t/p/original/fcWEbKJIBdClaZ4ovTMOrrQLWBS.jpg"
+          },
+          {
+            "alt" : "Taylor Swift: The Eras Tour",
+            "type" : "snapshot",
+            "url" : "https://metadata-static.plex.tv/6/gracenote/6162de2c938016d125d1d511d7dd59eb.jpg"
+          }
+        ]
+      },
+      {
+        "art" : "https://image.tmdb.org/t/p/original/2K84O2cr0jRH7ROeeHJ3zbTR8Uf.jpg",
+        "banner" : "https://artworks.thetvdb.com/banners/series/369301/banners/5eb4c60ab818d.jpg",
+        "guid" : "plex://show/5e2ae04287304c003e612d49",
+        "key" : "/library/metadata/5e2ae04287304c003e612d49/children",
+        "primaryExtraKey" : "/library/metadata/5e2ae04287304c003e612d49/extras/6204944306b37970e13c50df",
+        "rating" : 8.2,
+        "ratingKey" : "5e2ae04287304c003e612d49",
+        "studio" : "MRC",
+        "tagline" : "If the crown fits... take it.",
+        "type" : "show",
+        "theme" : "https://tvthemes.plexapp.com/369301.mp3",
+        "thumb" : "https://image.tmdb.org/t/p/original/tpz9UQ3hUwYufNcKWVW00FCjWyc.jpg",
+        "addedAt" : 1589414400,
+        "duration" : 95640000,
+        "publicPagesURL" : "https://watch.plex.tv/show/the-great",
+        "slug" : "the-great",
+        "userState" : false,
+        "title" : "The Great",
+        "leafCount" : 30,
+        "childCount" : 3,
+        "contentRating" : "TV-MA",
+        "originallyAvailableAt" : "2020-05-14",
+        "year" : 2020,
+        "ratingImage" : "imdb://image.rating",
+        "imdbRatingCount" : 51545,
+        "Image" : [
+          {
+            "alt" : "The Great",
+            "type" : "background",
+            "url" : "https://image.tmdb.org/t/p/original/2K84O2cr0jRH7ROeeHJ3zbTR8Uf.jpg"
+          },
+          {
+            "alt" : "The Great",
+            "type" : "banner",
+            "url" : "https://artworks.thetvdb.com/banners/series/369301/banners/5eb4c60ab818d.jpg"
+          },
+          {
+            "alt" : "The Great",
+            "type" : "clearLogoWide",
+            "url" : "http://assets.fanart.tv/fanart/tv/369301/hdtvlogo/the-great-5ea2790f41b74.png"
+          },
+          {
+            "alt" : "The Great",
+            "type" : "coverArt",
+            "url" : "https://metadata-static.plex.tv/2/gracenote/27810c3235b0c50f3868ee68f7fad267.jpg"
+          },
+          {
+            "alt" : "The Great",
+            "type" : "coverPoster",
+            "url" : "https://image.tmdb.org/t/p/original/tpz9UQ3hUwYufNcKWVW00FCjWyc.jpg"
+          },
+          {
+            "alt" : "The Great",
+            "type" : "coverSquare",
+            "url" : "https://metadata-static.plex.tv/1/gracenote/16d4b1f7e5450ddeb4080931fa27bb77.jpg"
+          }
+        ]
+      },
+      {
+        "art" : "https://image.tmdb.org/t/p/original/oahCTL082gwu6fYrxEOBe546uvB.jpg",
+        "banner" : "https://artworks.thetvdb.com/banners/v4/series/355730/banners/6184099bf091e.jpg",
+        "guid" : "plex://show/5d9c08e6ba6eb9001fbac2bb",
+        "key" : "/library/metadata/5d9c08e6ba6eb9001fbac2bb/children",
+        "primaryExtraKey" : "/library/metadata/5d9c08e6ba6eb9001fbac2bb/extras/6204944443b1eec43b424177",
+        "rating" : 7.1,
+        "ratingKey" : "5d9c08e6ba6eb9001fbac2bb",
+        "studio" : "Sony Pictures Television Studios",
+        "type" : "show",
+        "theme" : "https://tvthemes.plexapp.com/355730.mp3",
+        "thumb" : "https://image.tmdb.org/t/p/original/ihBi24EIr5kwAeY2PqmsgAcCj4n.jpg",
+        "addedAt" : 1637193600,
+        "duration" : 3360000,
+        "publicPagesURL" : "https://watch.plex.tv/show/the-wheel-of-time",
+        "slug" : "the-wheel-of-time",
+        "userState" : false,
+        "title" : "The Wheel of Time",
+        "leafCount" : 36,
+        "childCount" : 2,
+        "isContinuingSeries" : true,
+        "contentRating" : "TV-MA",
+        "originallyAvailableAt" : "2021-11-18",
+        "year" : 2021,
+        "ratingImage" : "imdb://image.rating",
+        "imdbRatingCount" : 128452,
+        "Image" : [
+          {
+            "alt" : "The Wheel of Time",
+            "type" : "background",
+            "url" : "https://image.tmdb.org/t/p/original/oahCTL082gwu6fYrxEOBe546uvB.jpg"
+          },
+          {
+            "alt" : "The Wheel of Time",
+            "type" : "banner",
+            "url" : "https://artworks.thetvdb.com/banners/v4/series/355730/banners/6184099bf091e.jpg"
+          },
+          {
+            "alt" : "The Wheel of Time",
+            "type" : "clearLogoWide",
+            "url" : "http://assets.fanart.tv/fanart/tv/355730/hdtvlogo/the-wheel-of-time-6197d9392faba.png"
+          },
+          {
+            "alt" : "The Wheel of Time",
+            "type" : "coverArt",
+            "url" : "https://metadata-static.plex.tv/b/gracenote/b06ee290163a9d3e37c831c912a1f938.jpg"
+          },
+          {
+            "alt" : "The Wheel of Time",
+            "type" : "coverPoster",
+            "url" : "https://image.tmdb.org/t/p/original/ihBi24EIr5kwAeY2PqmsgAcCj4n.jpg"
+          },
+          {
+            "alt" : "The Wheel of Time",
+            "type" : "coverSquare",
+            "url" : "https://metadata-static.plex.tv/0/gracenote/0806a5d01a0959ef9b8b032bbfd826e1.jpg"
+          }
+        ]
+      },
+      {
+        "art" : "https://image.tmdb.org/t/p/original/fm6KqXpk3M2HVveHwCrBSSBaO0V.jpg",
+        "banner" : "http://assets.fanart.tv/fanart/movies/872585/moviebanner/oppenheimer-639d665316a27.jpg",
+        "guid" : "plex://movie/613b69464d1516c90af83633",
+        "key" : "/library/metadata/613b69464d1516c90af83633",
+        "primaryExtraKey" : "/library/metadata/613b69464d1516c90af83633/extras/63a091a9244cd201463e9fd4",
+        "rating" : 9.3,
+        "ratingKey" : "613b69464d1516c90af83633",
+        "studio" : "Syncopy",
+        "tagline" : "The world forever changes.",
+        "type" : "movie",
+        "thumb" : "https://image.tmdb.org/t/p/original/ptpr0kGAckfQkJeJIt8st5dglvd.jpg",
+        "addedAt" : 1689724800,
+        "duration" : 10800000,
+        "publicPagesURL" : "https://watch.plex.tv/movie/untitled-oppenheimer-biopic",
+        "slug" : "untitled-oppenheimer-biopic",
+        "userState" : false,
+        "title" : "Oppenheimer",
+        "contentRating" : "R",
+        "originallyAvailableAt" : "2023-07-19",
+        "year" : 2023,
+        "audienceRating" : 9.1,
+        "audienceRatingImage" : "rottentomatoes://image.rating.upright",
+        "ratingImage" : "rottentomatoes://image.rating.ripe",
+        "imdbRatingCount" : 468574,
+        "Image" : [
+          {
+            "alt" : "Oppenheimer",
+            "type" : "background",
+            "url" : "https://image.tmdb.org/t/p/original/fm6KqXpk3M2HVveHwCrBSSBaO0V.jpg"
+          },
+          {
+            "alt" : "Oppenheimer",
+            "type" : "banner",
+            "url" : "http://assets.fanart.tv/fanart/movies/872585/moviebanner/oppenheimer-639d665316a27.jpg"
+          },
+          {
+            "alt" : "Oppenheimer",
+            "type" : "clearLogoWide",
+            "url" : "http://assets.fanart.tv/fanart/movies/872585/hdmovielogo/oppenheimer-63faf70a676ac.png"
+          },
+          {
+            "alt" : "Oppenheimer",
+            "type" : "coverArt",
+            "url" : "https://metadata-static.plex.tv/3/gracenote/30adfeebbbe05aabb7dcafb8d3108c68.jpg"
+          },
+          {
+            "alt" : "Oppenheimer",
+            "type" : "coverPoster",
+            "url" : "https://image.tmdb.org/t/p/original/ptpr0kGAckfQkJeJIt8st5dglvd.jpg"
+          },
+          {
+            "alt" : "Oppenheimer",
+            "type" : "coverSquare",
+            "url" : "https://metadata-static.plex.tv/e/gracenote/e1f331127d8d42a265f0e281b9a755a4.jpg"
+          },
+          {
+            "alt" : "Oppenheimer",
+            "type" : "snapshot",
+            "url" : "https://metadata-static.plex.tv/0/gracenote/00fab01de9cbecf7af68e458be122c26.jpg"
+          }
+        ]
+      },
+      {
+        "art" : "https://image.tmdb.org/t/p/original/zxfBtHz5UmSTfIEC4O4GngyjHwa.jpg",
+        "banner" : "https://artworks.thetvdb.com/banners/v4/series/421555/banners/64287525abbe9.jpg",
+        "guid" : "plex://show/62b355e8c2185650f860644f",
+        "key" : "/library/metadata/62b355e8c2185650f860644f/children",
+        "rating" : 7.7,
+        "ratingKey" : "62b355e8c2185650f860644f",
+        "studio" : "Tencent Penguin Pictures",
+        "subtype" : "miniSeries",
+        "type" : "show",
+        "theme" : "https://tvthemes.plexapp.com/421555.mp3",
+        "thumb" : "https://image.tmdb.org/t/p/original/buXHm2shttFRQIBsCFlv5L2TmKh.jpg",
+        "addedAt" : 1673740800,
+        "duration" : 2580000,
+        "publicPagesURL" : "https://watch.plex.tv/show/the-three-body-problem-2",
+        "slug" : "the-three-body-problem-2",
+        "userState" : false,
+        "title" : "Three-Body",
+        "originalTitle" : "三体",
+        "leafCount" : 30,
+        "childCount" : 1,
+        "skipChildren" : true,
+        "contentRating" : "TV-14",
+        "originallyAvailableAt" : "2023-01-15",
+        "year" : 2023,
+        "ratingImage" : "imdb://image.rating",
+        "imdbRatingCount" : 3210,
+        "Image" : [
+          {
+            "alt" : "Three-Body",
+            "type" : "background",
+            "url" : "https://image.tmdb.org/t/p/original/zxfBtHz5UmSTfIEC4O4GngyjHwa.jpg"
+          },
+          {
+            "alt" : "Three-Body",
+            "type" : "banner",
+            "url" : "https://artworks.thetvdb.com/banners/v4/series/421555/banners/64287525abbe9.jpg"
+          },
+          {
+            "alt" : "Three-Body",
+            "type" : "clearLogoWide",
+            "url" : "http://assets.fanart.tv/fanart/tv/421555/hdtvlogo/three-body-641091fc40aa5.png"
+          },
+          {
+            "alt" : "Three-Body",
+            "type" : "coverArt",
+            "url" : "https://metadata-static.plex.tv/2/gracenote/2ce22bcfd4e6a3d1b97c88e4e355d7d7.jpg"
+          },
+          {
+            "alt" : "Three-Body",
+            "type" : "coverPoster",
+            "url" : "https://image.tmdb.org/t/p/original/buXHm2shttFRQIBsCFlv5L2TmKh.jpg"
+          },
+          {
+            "alt" : "Three-Body",
+            "type" : "coverSquare",
+            "url" : "https://metadata-static.plex.tv/4/gracenote/4dd4ba00ac051d1fbc084b605ebeb175.jpg"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/test/scala/PlexTokenSpec.scala
+++ b/src/test/scala/PlexTokenSpec.scala
@@ -1,0 +1,28 @@
+import PlexToken.{jsonToUserList, selfWatchlistToItems}
+import io.circe.Json
+import io.circe.syntax.EncoderOps
+import model._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import io.circe.parser._
+
+import scala.io.Source
+
+class PlexTokenSpec extends AnyFlatSpec with Matchers {
+
+  "PlexTokenSpec" should "correctly deserialize users" in {
+    val jsonStr = Source.fromResource("users.json").getLines().mkString("\n")
+
+    val decodedUsers = jsonToUserList(parse(jsonStr).getOrElse(Json.Null))
+
+    decodedUsers.isEmpty shouldBe false
+  }
+
+  it should "correctly deserialize my own watchlist" in {
+    val jsonStr = Source.fromResource("watchlist-from-token.json").getLines().mkString("\n")
+
+    val decodedItems = selfWatchlistToItems(parse(jsonStr).getOrElse(Json.Null))
+
+    decodedItems.isEmpty shouldBe false
+  }
+}


### PR DESCRIPTION
Started as part of addressing #17 

The challenge here is that the Plex GraphQL query does not return an ID that can be matched against something in Sonarr/Radarr. It only returns a title, which may or may not match.

I think we'll need to look up the closest match IDs using the sonarr API in order to make a good match? Will investigate