### PR TITLE
Automate RSS Feed Generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ Sync plex watchlists in realtime with Sonarr and Radarr.
 
 There are several ways of fetching watchlist information from Plex
 
-| Method                                  | Pros                                                                    | Cons                                                                                                            | Supported by Watchlistarr | Supported by Overseer/Ombi | Supported by Sonarr/Radarr   |
-|-----------------------------------------|-------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------|---------------------------|----------------------------|------------------------------|
-| Plex Watchlist RSS Feeds                | Fast and instantly updated, can create one for self and one for friends | Will only show the most recent 50 movies/shows                                                                  | Yes                       | X                          | Yes, refreshes every 6 hours |
-| Plex Watchlist Metadata                 | Can fetch the full watchlist for the user                               | Need a plex token for each user who wants to have their watchlist synced, Plex token expires after a few months | Yes, on first startup     | Yes, not real-time         | X                            |
-| Plex Watchlist GraphQL Call             | Can fetch the full watchlist for every friend of the main user          | Slow, relies on main user providing a plex token                                                                | Yes, on first startup     | X                          | X                            |
-| Plex Watchlist Metadata for other users | Can fetch the full watchlist for every user who provides a token        | Difficult to ask every user to generate a Plex token, or log into a service                                     | Coming Soon               | Yes, not real-time         | X                            |
+| Method                                  | Pros                                                                    | Cons                                                                                                            | Supported by Watchlistarr | Supported by Overseer/Ombi | Supported by Sonarr/Radarr             |
+|-----------------------------------------|-------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------|---------------------------|----------------------------|----------------------------------------|
+| Plex Watchlist RSS Feeds                | Fast and instantly updated, can create one for self and one for friends | Will only show the most recent 50 movies/shows                                                                  | Yes                       | X                          | Only for self, refreshes every 6 hours |
+| Plex Watchlist Metadata                 | Can fetch the full watchlist for the user                               | Need a plex token for each user who wants to have their watchlist synced, Plex token expires after a few months | Yes                       | Yes, up to 5 min intervals | X                                      |
+| Plex Watchlist GraphQL Call             | Can fetch the full watchlist for every friend of the main user          | Slow, relies on main user providing a plex token                                                                | Yes                       | X                          | X                                      |
+| Plex Watchlist Metadata for other users | Can fetch the full watchlist for every user who provides a token        | Difficult to ask every user to generate a Plex token, or log into a service                                     | Yes                       | Yes, up to 5 min intervals | X                                      |
 
 In order to fully integrate with Plex Watchlists, Watchlistarr uses a combination of multiple methods to ensure that it
 does a comprehensive, yet fast real-time sync.
@@ -24,7 +24,8 @@ Watchlistarr is working towards being able to support a full delete sync with yo
 a user
 removes an item off their watchlist, Watchlistarr can detect that and delete content from Sonarr/Radarr.**
 
-This feature is still in beta, and will be released soon.
+This feature will be released soon, in the meantime, you can enjoy a little "sneak peak"
+upon startup of the app, where the logs will list the movies/tv shows that are out of sync.
 
 ### Requirements
 
@@ -44,15 +45,9 @@ The easiest way to try this code is using docker:
 docker run \
   -e SONARR_API_KEY=YOUR_API_KEY \
   -e RADARR_API_KEY=YOUR_API_KEY \
-  -e PLEX_WATCHLIST_URL_1=YOUR_PLEX_WATCHLIST_URL \
+  -e PLEX_TOKEN=YOUR_PLEX_TOKEN \
   -e REFRESH_INTERVAL_SECONDS=5 \
   nylonee/watchlistarr
-```
-
-If you also have a Plex token in hand, you can add it to the command above to enhance your experience:
-
-```bash
-  -e PLEX_TOKEN=YOUR_PLEX_TOKEN \
 ```
 
 For a full list of possible environment variables to configure the app with, see the Environment Variables section of
@@ -71,32 +66,32 @@ Running this using native java requires the fat jar, download the latest from th
 ```bash
 java -Dsonarr.apikey=YOUR_API_KEY\
   -Dradarr.apikey=YOUR_API_KEY\
-  -Dplex.watchlist1=YOUR_PLEX_WATCHLIST_URL\
+  -Dplex.token=YOUR_PLEX_TOKEN\
   -jar watchlistarr.java
 ```
 
-For a full list of options to pass in,
-see [entrypoint.sh](https://github.com/nylonee/watchlistarr/blob/main/docker/entrypoint.sh)
+For a full list of options to pass in when running the application on native java,
+refer to the environment variables chart below, and cross-reference the key to the internal key
+in [entrypoint.sh](https://github.com/nylonee/watchlistarr/blob/main/docker/entrypoint.sh)
 
 ### Environment Variables
 
-| Key                      | Default               | Description                                                                                                                                                                                |
-|--------------------------|-----------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| SONARR_API_KEY*          |                       | API key for Sonarr, found in your Sonarr UI -> General settings                                                                                                                            |
-| RADARR_API_KEY*          |                       | API key for Radarr, found in your Radarr UI -> General settings                                                                                                                            |
-| PLEX_WATCHLIST_URL_1*    |                       | First Plex Watchlist URL, generated via [this link](https://app.plex.tv/desktop/#!/settings/watchlist)                                                                                     |
-| PLEX_WATCHLIST_URL_2     |                       | Second Plex Watchlist URL (if applicable)                                                                                                                                                  |
-| PLEX_TOKEN               |                       | Token for Plex, retrieved via [this tutorial](https://support.plex.tv/articles/204059436-finding-an-authentication-token-x-plex-token/)                                                    |
-| REFRESH_INTERVAL_SECONDS | 60                    | Number of seconds to wait in between checking the watchlist                                                                                                                                |
-| SONARR_BASE_URL          | http://localhost:8989 | Base URL for Sonarr, including the 'http' and port and any configured urlbase                                                                                                              |
-| SONARR_QUALITY_PROFILE   |                       | Quality profile for Sonarr, found in your Sonarr UI -> Profiles settings. If not set, will grab the first one it finds on Sonarr                                                           |
-| SONARR_ROOT_FOLDER       |                       | Root folder for Sonarr. If not set, will grab the first one it finds on Sonarr                                                                                                             |
-| SONARR_BYPASS_IGNORED    | false                 | Boolean flag to bypass tv shows that are on the Sonarr Exclusion List                                                                                                                      |
-| SONARR_SEASON_MONITORING | all                   | Default monitoring for new seasons added to Sonarr. Full list of options are found in the [Sonarr API Docs](https://sonarr.tv/docs/api/#/Series/post_api_v3_series) under **MonitorTypes** |
-| RADARR_BASE_URL          | http://127.0.0.1:7878 | Base URL for Radarr, including the 'http' and port and any configured urlbase                                                                                                              |
-| RADARR_QUALITY_PROFILE   |                       | Quality profile for Radarr, found in your Radarr UI -> Profiles settings. If not set, will grab the first one it finds on Radarr                                                           |
-| RADARR_ROOT_FOLDER       |                       | Root folder for Radarr. If not set, will grab the first one it finds on Radarr                                                                                                             |
-| RADARR_BYPASS_IGNORED    | false                 | Boolean flag to bypass movies that are on the Radarr Exclusion List                                                                                                                        |
+| Key                      | Default               | Description                                                                                                                                                                                         |
+|--------------------------|-----------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| SONARR_API_KEY*          |                       | API key for Sonarr, found in your Sonarr UI -> General settings                                                                                                                                     |
+| RADARR_API_KEY*          |                       | API key for Radarr, found in your Radarr UI -> General settings                                                                                                                                     |
+| PLEX_TOKEN*              |                       | Token for Plex, retrieved via [this tutorial](https://support.plex.tv/articles/204059436-finding-an-authentication-token-x-plex-token/). Note that multiple tokens can be provided, comma separated |
+| REFRESH_INTERVAL_SECONDS | 60                    | Number of seconds to wait in between checking the watchlist                                                                                                                                         |
+| SONARR_BASE_URL          | http://localhost:8989 | Base URL for Sonarr, including the 'http' and port and any configured urlbase                                                                                                                       |
+| SONARR_QUALITY_PROFILE   |                       | Quality profile for Sonarr, found in your Sonarr UI -> Profiles settings. If not set, will grab the first one it finds on Sonarr                                                                    |
+| SONARR_ROOT_FOLDER       |                       | Root folder for Sonarr. If not set, will grab the first one it finds on Sonarr                                                                                                                      |
+| SONARR_BYPASS_IGNORED    | false                 | Boolean flag to bypass tv shows that are on the Sonarr Exclusion List                                                                                                                               |
+| SONARR_SEASON_MONITORING | all                   | Default monitoring for new seasons added to Sonarr. Full list of options are found in the [Sonarr API Docs](https://sonarr.tv/docs/api/#/Series/post_api_v3_series) under **MonitorTypes**          |
+| RADARR_BASE_URL          | http://127.0.0.1:7878 | Base URL for Radarr, including the 'http' and port and any configured urlbase                                                                                                                       |
+| RADARR_QUALITY_PROFILE   |                       | Quality profile for Radarr, found in your Radarr UI -> Profiles settings. If not set, will grab the first one it finds on Radarr                                                                    |
+| RADARR_ROOT_FOLDER       |                       | Root folder for Radarr. If not set, will grab the first one it finds on Radarr                                                                                                                      |
+| RADARR_BYPASS_IGNORED    | false                 | Boolean flag to bypass movies that are on the Radarr Exclusion List                                                                                                                                 |
+| SKIP_FRIEND_SYNC         | false                 | Boolean flag to toggle between only syncing your own content, vs syncing your own and all your friends content                                                                                      |
 
 ## Developers Corner
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ upon startup of the app, where the logs will list the movies/tv shows that are o
 * Radarr v3 or higher
 * Friends must change their privacy settings so that the main user can see their watchlists
 * Docker or Java
+* Plex Token (see [here](https://support.plex.tv/articles/204059436-finding-an-authentication-token-x-plex-token/))
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Watchlistarr is working towards being able to support a full delete sync with yo
 a user
 removes an item off their watchlist, Watchlistarr can detect that and delete content from Sonarr/Radarr.**
 
-This feature will be released soon, in the meantime, you can enjoy a little "sneak peak"
+This feature will be released soon, in the meantime, you can enjoy a little "sneak peek"
 upon startup of the app, where the logs will list the movies/tv shows that are out of sync.
 
 ### Requirements

--- a/src/main/scala/PlexTokenDeleteSync.scala
+++ b/src/main/scala/PlexTokenDeleteSync.scala
@@ -40,10 +40,10 @@ object PlexTokenDeleteSync extends PlexUtils with SonarrUtils with RadarrUtils {
           logger.debug(s"$c \"${item.title}\" already exists in Plex")
           Right(IO.unit)
         case (false, "show") =>
-          logger.info(s"Found show \"${item.title}\" which is not on Plex")
+          logger.info(s"Found show \"${item.title}\" which is not watchlisted on Plex")
           Right(IO.unit)
         case (false, "movie") =>
-          logger.info(s"Found movie \"${item.title}\" which is not on Plex")
+          logger.info(s"Found movie \"${item.title}\" which is not watchlisted on Plex")
           Right(IO.unit)
         case (false, c) =>
           logger.warn(s"Found $c \"${item.title}\", but I don't recognize the category")

--- a/src/main/scala/PlexTokenDeleteSync.scala
+++ b/src/main/scala/PlexTokenDeleteSync.scala
@@ -13,10 +13,10 @@ object PlexTokenDeleteSync extends PlexUtils with SonarrUtils with RadarrUtils {
 
   private val logger = LoggerFactory.getLogger(getClass)
 
-  def run(config: Configuration, client: HttpClient): IO[Unit] =  {
+  def run(config: Configuration, client: HttpClient): IO[Unit] = {
     val result = for {
       selfWatchlist <- getSelfWatchlist(config, client)
-      othersWatchlist <- getOthersWatchlist(config, client)
+      othersWatchlist <- if (config.skipFriendSync) EitherT.pure[IO, Throwable](Set.empty[Item]) else getOthersWatchlist(config, client)
       moviesWithoutExclusions <- fetchMovies(client)(config.radarrApiKey, config.radarrBaseUrl, bypass = true)
       seriesWithoutExclusions <- fetchSeries(client)(config.sonarrApiKey, config.sonarrBaseUrl, bypass = true)
       allIdsWithoutExclusions = moviesWithoutExclusions ++ seriesWithoutExclusions

--- a/src/main/scala/WatchlistSync.scala
+++ b/src/main/scala/WatchlistSync.scala
@@ -19,7 +19,7 @@ object WatchlistSync
     logger.debug("Starting watchlist sync")
 
     val result = for {
-      watchlistDatas <- EitherT[IO, Throwable, List[Set[Item]]](config.plexWatchlistUrls.map(fetchWatchlistFromRss(client)).sequence.map(Right(_)))
+      watchlistDatas <- EitherT[IO, Throwable, List[Set[Item]]](config.plexWatchlistUrls.map(fetchWatchlistFromRss(client)).toList.sequence.map(Right(_)))
       watchlistData = watchlistDatas.flatten.toSet
       movies <- fetchMovies(client)(config.radarrApiKey, config.radarrBaseUrl, config.radarrBypassIgnored)
       series <- fetchSeries(client)(config.sonarrApiKey, config.sonarrBaseUrl, config.sonarrBypassIgnored)

--- a/src/main/scala/configuration/Configuration.scala
+++ b/src/main/scala/configuration/Configuration.scala
@@ -17,6 +17,6 @@ case class Configuration(
                           radarrQualityProfileId: Int,
                           radarrRootFolder: String,
                           radarrBypassIgnored: Boolean,
-                          plexWatchlistUrls: List[Uri],
-                          plexToken: Option[String]
+                          plexWatchlistUrls: Set[Uri],
+                          plexTokens: Set[String]
                         )

--- a/src/main/scala/configuration/Configuration.scala
+++ b/src/main/scala/configuration/Configuration.scala
@@ -18,5 +18,6 @@ case class Configuration(
                           radarrRootFolder: String,
                           radarrBypassIgnored: Boolean,
                           plexWatchlistUrls: Set[Uri],
-                          plexTokens: Set[String]
+                          plexTokens: Set[String],
+                          skipFriendSync: Boolean
                         )

--- a/src/main/scala/configuration/ConfigurationUtils.scala
+++ b/src/main/scala/configuration/ConfigurationUtils.scala
@@ -128,7 +128,9 @@ object ConfigurationUtils {
         )
     }
 
-  private def normalizePath(path: String): String = if (path.endsWith("/") && path.length > 1) path.dropRight(1) else path
+  private def normalizePath(path: String): String =
+    (if (path.endsWith("/") && path.length > 1) path.dropRight(1) else path)
+      .replace("//", "/")
 
   private def getPlexWatchlistUrls(client: HttpClient)(configReader: ConfigurationReader, tokens: Set[String]): IO[Set[Uri]] = {
     val watchlistsFromConfigDeprecated = Set(

--- a/src/main/scala/configuration/ConfigurationUtils.scala
+++ b/src/main/scala/configuration/ConfigurationUtils.scala
@@ -1,11 +1,14 @@
 package configuration
 
 import cats.effect.IO
+import cats.implicits.toTraverseOps
 import http.HttpClient
 import io.circe.generic.auto._
 import io.circe.Json
+import io.circe.syntax.EncoderOps
 import org.http4s.{Method, Uri}
 import org.slf4j.LoggerFactory
+import plex.RssFeedGenerated
 
 import scala.concurrent.duration._
 
@@ -23,8 +26,8 @@ object ConfigurationUtils {
       radarrConfig <- getRadarrConfig(configReader, client)
       (radarrBaseUrl, radarrApiKey, radarrQualityProfileId, radarrRootFolder) = radarrConfig
       radarrBypassIgnored = configReader.getConfigOption(Keys.radarrBypassIgnored).exists(_.toBoolean)
-      plexWatchlistUrls = getPlexWatchlistUrls(configReader)
-      plexToken = configReader.getConfigOption(Keys.plexToken)
+      plexTokens = getPlexTokens(configReader)
+      plexWatchlistUrls <- getPlexWatchlistUrls(client)(configReader, plexTokens)
     } yield Configuration(
       refreshInterval,
       sonarrBaseUrl,
@@ -39,7 +42,7 @@ object ConfigurationUtils {
       radarrRootFolder,
       radarrBypassIgnored,
       plexWatchlistUrls,
-      plexToken
+      plexTokens
     )
 
   private def getSonarrConfig(configReader: ConfigurationReader, client: HttpClient): IO[(Uri, String, Int, String)] = {
@@ -128,17 +131,40 @@ object ConfigurationUtils {
 
   private def normalizePath(path: String): String = if (path.endsWith("/") && path.length > 1) path.dropRight(1) else path
 
-  private def getPlexWatchlistUrls(configReader: ConfigurationReader): List[Uri] =
-    Set(
+  private def getPlexWatchlistUrls(client: HttpClient)(configReader: ConfigurationReader, tokens: Set[String]): IO[Set[Uri]] = {
+    val watchlistsFromConfigDeprecated = Set(
       configReader.getConfigOption(Keys.plexWatchlist1),
       configReader.getConfigOption(Keys.plexWatchlist2)
-    ).toList.collect {
+    ).collect {
       case Some(url) => url
-    } match {
-      case Nil =>
-        throwError("Missing plex watchlist URL")
-      case other => other.map(toPlexUri)
     }
+
+    val watchlistsFromTokenIo = tokens.map { token =>
+      for {
+        selfWatchlist <- getRssFromPlexToken(client)(token, "watchlist")
+        otherWatchlist <- getRssFromPlexToken(client)(token, "friendsWatchlist")
+      } yield Set(selfWatchlist, otherWatchlist).collect {
+        case Some(url) => url
+      }
+    }.toList.sequence.map(_.flatten)
+
+    watchlistsFromTokenIo.map { watchlistsFromToken =>
+      (watchlistsFromConfigDeprecated ++ watchlistsFromToken).toList match {
+        case Nil =>
+          throwError("Missing plex watchlist URL")
+        case other => other.map(toPlexUri).toSet
+      }
+    }
+  }
+
+  private def getPlexTokens(configReader: ConfigurationReader): Set[String] = {
+    configReader.getConfigOption(Keys.plexToken) match {
+      case Some(rawToken) =>
+        rawToken.split(',').toSet
+      case None =>
+        throwError("Missing plex token")
+    }
+  }
 
   private def toPlexUri(url: String): Uri = {
     val supportedHosts = List(
@@ -166,5 +192,28 @@ object ConfigurationUtils {
 
   private def getToArr(client: HttpClient)(baseUrl: Uri, apiKey: String, endpoint: String): IO[Either[Throwable, Json]] =
     client.httpRequest(Method.GET, baseUrl / "api" / "v3" / endpoint, Some(apiKey))
+
+  private def getRssFromPlexToken(client: HttpClient)(token: String, rssType: String): IO[Option[String]] = {
+    val url = Uri
+      .unsafeFromString("https://discover.provider.plex.tv/rss")
+      .withQueryParam("X-Plex-Token", token)
+
+    val body = s"""{"feedtype": "$rssType"}""".asJson
+
+    client.httpRequest(Method.POST, url, None, Some(body)).map {
+      case Left(err) =>
+        logger.warn(s"Unable to generate an RSS feed: $err")
+        None
+      case Right(json) =>
+        logger.debug("Got a result from Plex when generating RSS feed, attempting to decode")
+        json.as[RssFeedGenerated].map(_.RSSInfo.head.url) match {
+          case Left(err) =>
+            logger.warn(s"Unable to decode RSS generation response: $err, returning None instead")
+            None
+          case Right(url) =>
+            Some(url)
+        }
+    }
+  }
 
 }

--- a/src/main/scala/configuration/ConfigurationUtils.scala
+++ b/src/main/scala/configuration/ConfigurationUtils.scala
@@ -143,7 +143,9 @@ object ConfigurationUtils {
     val watchlistsFromTokenIo = tokens.map { token =>
       for {
         selfWatchlist <- getRssFromPlexToken(client)(token, "watchlist")
+        _ = logger.info(s"Generated watchlist RSS feed for self: $selfWatchlist")
         otherWatchlist <- getRssFromPlexToken(client)(token, "friendsWatchlist")
+        _ = logger.info(s"Generated watchlist RSS feed for friends: $otherWatchlist")
       } yield Set(selfWatchlist, otherWatchlist).collect {
         case Some(url) => url
       }
@@ -158,14 +160,14 @@ object ConfigurationUtils {
     }
   }
 
-  private def getPlexTokens(configReader: ConfigurationReader): Set[String] = {
+  private def getPlexTokens(configReader: ConfigurationReader): Set[String] =
     configReader.getConfigOption(Keys.plexToken) match {
       case Some(rawToken) =>
         rawToken.split(',').toSet
       case None =>
-        throwError("Missing plex token")
+        logger.warn("Missing plex token")
+        Set.empty
     }
-  }
 
   private def toPlexUri(url: String): Uri = {
     val supportedHosts = List(

--- a/src/main/scala/configuration/ConfigurationUtils.scala
+++ b/src/main/scala/configuration/ConfigurationUtils.scala
@@ -208,7 +208,7 @@ object ConfigurationUtils {
       .withQueryParam("X-Plex-Token", token)
       .withQueryParam("X-Plex-Client-Identifier", "watchlistarr")
 
-    val body = Json.obj(("feedtype", Json.fromString(rssType)))
+    val body = Json.obj(("feedType", Json.fromString(rssType)))
 
     client.httpRequest(Method.POST, url, None, Some(body)).map {
       case Left(err) =>

--- a/src/main/scala/configuration/Keys.scala
+++ b/src/main/scala/configuration/Keys.scala
@@ -19,4 +19,5 @@ private[configuration] object Keys {
   val plexWatchlist1 = "plex.watchlist1"
   val plexWatchlist2 = "plex.watchlist2"
   val plexToken = "plex.token"
+  val skipFriendSync = "plex.skipfriendsync"
 }

--- a/src/main/scala/http/HttpClient.scala
+++ b/src/main/scala/http/HttpClient.scala
@@ -3,6 +3,7 @@ package http
 import cats.effect.IO
 import io.circe.Json
 import org.http4s.circe._
+import org.http4s.client.middleware.FollowRedirect
 import org.http4s.ember.client.EmberClientBuilder
 import org.http4s.{Header, Method, Request, Uri}
 import org.typelevel.ci.CIString
@@ -10,12 +11,16 @@ import org.typelevel.ci.CIString
 class HttpClient {
 
   val client = EmberClientBuilder.default[IO].build
+    .map(FollowRedirect(5))
 
   def httpRequest(method: Method, url: Uri, apiKey: Option[String] = None, payload: Option[Json] = None): IO[Either[Throwable, Json]] = {
+    val host = s"${url.host.getOrElse(Uri.Host.unsafeFromString("127.0.0.1")).value}"
+
     val baseRequest = Request[IO](method = method, uri = url)
       .withHeaders(
         Header.Raw(CIString("Accept"), "application/json"),
-        Header.Raw(CIString("Content-Type"), "application/json")
+        Header.Raw(CIString("Content-Type"), "application/json"),
+        Header.Raw(CIString("Host"), host)
       )
     val requestWithApiKey = apiKey.fold(baseRequest)(key => baseRequest.withHeaders(
       Header.Raw(CIString("X-Api-Key"), key),
@@ -24,8 +29,6 @@ class HttpClient {
     ))
     val requestWithPayload = payload.fold(requestWithApiKey)(p => requestWithApiKey.withEntity(p))
 
-
-    println(s"Headers: ${requestWithPayload.headers}")
     client.use(_.expect[Json](requestWithPayload).attempt)
   }
 }

--- a/src/main/scala/http/HttpClient.scala
+++ b/src/main/scala/http/HttpClient.scala
@@ -24,6 +24,8 @@ class HttpClient {
     ))
     val requestWithPayload = payload.fold(requestWithApiKey)(p => requestWithApiKey.withEntity(p))
 
+
+    println(s"Headers: ${requestWithPayload.headers}")
     client.use(_.expect[Json](requestWithPayload).attempt)
   }
 }

--- a/src/main/scala/plex/PlexUtils.scala
+++ b/src/main/scala/plex/PlexUtils.scala
@@ -151,7 +151,7 @@ trait PlexUtils {
     val key = cleanKey(i.key)
     val url = Uri
       .unsafeFromString(s"https://discover.provider.plex.tv$key")
-      .withQueryParam("X-Plex-Token", config.plexTokens.head)
+      .withQueryParam("X-Plex-Token", config.plexTokens.headOption.getOrElse("unknown"))
 
     val guids: EitherT[IO, Throwable, List[String]] = for {
       response <- EitherT(client.httpRequest(Method.GET, url))

--- a/src/main/scala/plex/RssFeedGenerated.scala
+++ b/src/main/scala/plex/RssFeedGenerated.scala
@@ -1,5 +1,5 @@
 package plex
 
-case class RssFeedGenerated(RSSInfo: List[RssInfo])
+case class RssFeedGenerated(RSSInfo: RssInfo)
 
-case class RssInfo(url: String)
+case class RssInfo(watchlistUrl: String)

--- a/src/main/scala/plex/RssFeedGenerated.scala
+++ b/src/main/scala/plex/RssFeedGenerated.scala
@@ -1,0 +1,5 @@
+package plex
+
+case class RssFeedGenerated(RSSInfo: List[RssInfo])
+
+case class RssInfo(url: String)

--- a/src/main/scala/plex/RssFeedGenerated.scala
+++ b/src/main/scala/plex/RssFeedGenerated.scala
@@ -1,5 +1,5 @@
 package plex
 
-case class RssFeedGenerated(RSSInfo: RssInfo)
+case class RssFeedGenerated(RSSInfo: List[RssInfo])
 
-case class RssInfo(watchlistUrl: String)
+case class RssInfo(url: String)

--- a/src/test/resources/rss-feed-generated.json
+++ b/src/test/resources/rss-feed-generated.json
@@ -1,0 +1,9 @@
+{
+  "RSSInfo": [
+    {
+      "feedType": "friendsWatchlist",
+      "uuid": "b5adbd07-fc91-4636-b77a-89f34a703473",
+      "url": "https://rss.plex.tv/b5adbd07-fc91-4636-b77a-89f34a703473"
+    }
+  ]
+}

--- a/src/test/resources/rss-feed-generated.json
+++ b/src/test/resources/rss-feed-generated.json
@@ -1,6 +1,9 @@
 {
-  "RSSInfo": {
-    "watchlistUuid": "b5adbd07-fc91-4636-b77a-89f34a703473",
-    "watchlistUrl": "https://rss.plex.tv/b5adbd07-fc91-4636-b77a-89f34a703473"
-  }
+  "RSSInfo": [
+    {
+      "feedType": "friendsWatchlist",
+      "uuid": "b5adbd07-fc91-4636-b77a-89f34a703473",
+      "url": "https://rss.plex.tv/b5adbd07-fc91-4636-b77a-89f34a703473"
+    }
+  ]
 }

--- a/src/test/resources/rss-feed-generated.json
+++ b/src/test/resources/rss-feed-generated.json
@@ -1,9 +1,6 @@
 {
-  "RSSInfo": [
-    {
-      "feedType": "friendsWatchlist",
-      "uuid": "b5adbd07-fc91-4636-b77a-89f34a703473",
-      "url": "https://rss.plex.tv/b5adbd07-fc91-4636-b77a-89f34a703473"
-    }
-  ]
+  "RSSInfo": {
+    "watchlistUuid": "b5adbd07-fc91-4636-b77a-89f34a703473",
+    "watchlistUrl": "https://rss.plex.tv/b5adbd07-fc91-4636-b77a-89f34a703473"
+  }
 }

--- a/src/test/scala/PlexTokenSyncSpec.scala
+++ b/src/test/scala/PlexTokenSyncSpec.scala
@@ -46,7 +46,8 @@ class PlexTokenSyncSpec extends AnyFlatSpec with Matchers with MockFactory {
     radarrRootFolder = "/root/",
     radarrBypassIgnored = false,
     plexWatchlistUrls = Set(Uri.unsafeFromString("https://localhost:9090")),
-    plexTokens = plexTokens
+    plexTokens = plexTokens,
+    skipFriendSync = false
   )
 
   private def defaultPlexMock(httpClient: HttpClient): HttpClient = {

--- a/src/test/scala/PlexTokenSyncSpec.scala
+++ b/src/test/scala/PlexTokenSyncSpec.scala
@@ -20,7 +20,7 @@ class PlexTokenSyncSpec extends AnyFlatSpec with Matchers with MockFactory {
   "PlexTokenSync.run" should "do a single sync with all required fields provided" in {
 
     val mockHttpClient = mock[HttpClient]
-    val config = createConfiguration(plexToken = Some("plex-token"))
+    val config = createConfiguration(plexTokens = Set("plex-token"))
     defaultPlexMock(mockHttpClient)
     defaultRadarrMock(mockHttpClient)
     defaultSonarrMock(mockHttpClient)
@@ -31,7 +31,7 @@ class PlexTokenSyncSpec extends AnyFlatSpec with Matchers with MockFactory {
   }
 
   private def createConfiguration(
-                                   plexToken: Option[String]
+                                   plexTokens: Set[String]
                                  ): Configuration = Configuration(
     refreshInterval = 10.seconds,
     sonarrBaseUrl = Uri.unsafeFromString("https://localhost:8989"),
@@ -45,8 +45,8 @@ class PlexTokenSyncSpec extends AnyFlatSpec with Matchers with MockFactory {
     radarrQualityProfileId = 1,
     radarrRootFolder = "/root/",
     radarrBypassIgnored = false,
-    plexWatchlistUrls = List(Uri.unsafeFromString("https://localhost:9090")),
-    plexToken = plexToken
+    plexWatchlistUrls = Set(Uri.unsafeFromString("https://localhost:9090")),
+    plexTokens = plexTokens
   )
 
   private def defaultPlexMock(httpClient: HttpClient): HttpClient = {

--- a/src/test/scala/WatchlistSyncSpec.scala
+++ b/src/test/scala/WatchlistSyncSpec.scala
@@ -199,8 +199,8 @@ class WatchlistSyncSpec extends AnyFlatSpec with Matchers with MockFactory {
     radarrQualityProfileId = 1,
     radarrRootFolder = "/root/",
     radarrBypassIgnored = radarrBypassIgnored,
-    plexWatchlistUrls = List(plexWatchlistUrl),
-    plexToken = None
+    plexWatchlistUrls = Set(plexWatchlistUrl),
+    plexTokens = Set("test-token")
   )
 
   private def defaultPlexMock(httpClient: HttpClient): HttpClient = {

--- a/src/test/scala/WatchlistSyncSpec.scala
+++ b/src/test/scala/WatchlistSyncSpec.scala
@@ -200,7 +200,8 @@ class WatchlistSyncSpec extends AnyFlatSpec with Matchers with MockFactory {
     radarrRootFolder = "/root/",
     radarrBypassIgnored = radarrBypassIgnored,
     plexWatchlistUrls = Set(plexWatchlistUrl),
-    plexTokens = Set("test-token")
+    plexTokens = Set("test-token"),
+    skipFriendSync = false
   )
 
   private def defaultPlexMock(httpClient: HttpClient): HttpClient = {

--- a/src/test/scala/configuration/ConfigurationUtilsSpec.scala
+++ b/src/test/scala/configuration/ConfigurationUtilsSpec.scala
@@ -3,6 +3,7 @@ package configuration
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import http.HttpClient
+import io.circe.Json
 import org.http4s.{Method, Uri}
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.flatspec.AnyFlatSpec
@@ -191,15 +192,15 @@ class ConfigurationUtilsSpec extends AnyFlatSpec with Matchers with MockFactory 
     ).returning(IO.pure(parse(Source.fromResource("rootFolder.json").getLines().mkString("\n")))).anyNumberOfTimes()
     (mockHttpClient.httpRequest _).expects(
       Method.POST,
-      Uri.unsafeFromString("https://discover.provider.plex.tv/rss?X-Plex-Token=test-token"),
+      Uri.unsafeFromString("https://discover.provider.plex.tv/rss?X-Plex-Token=test-token&X-Plex-Client-Identifier=watchlistarr"),
       None,
-      Some("""{"feedtype": "watchlist"}""".asJson)
+      Some(parse("""{"feedtype": "watchlist"}""").getOrElse(Json.Null))
     ).returning(IO.pure(parse(Source.fromResource("rss-feed-generated.json").getLines().mkString("\n")))).anyNumberOfTimes()
     (mockHttpClient.httpRequest _).expects(
       Method.POST,
-      Uri.unsafeFromString("https://discover.provider.plex.tv/rss?X-Plex-Token=test-token"),
+      Uri.unsafeFromString("https://discover.provider.plex.tv/rss?X-Plex-Token=test-token&X-Plex-Client-Identifier=watchlistarr"),
       None,
-      Some("""{"feedtype": "friendsWatchlist"}""".asJson)
+      Some(parse("""{"feedtype": "friendsWatchlist"}""").getOrElse(Json.Null))
     ).returning(IO.pure(parse(Source.fromResource("rss-feed-generated.json").getLines().mkString("\n")))).anyNumberOfTimes()
     mockHttpClient
   }

--- a/src/test/scala/configuration/ConfigurationUtilsSpec.scala
+++ b/src/test/scala/configuration/ConfigurationUtilsSpec.scala
@@ -202,13 +202,13 @@ class ConfigurationUtilsSpec extends AnyFlatSpec with Matchers with MockFactory 
       Method.POST,
       Uri.unsafeFromString("https://discover.provider.plex.tv/rss?X-Plex-Token=test-token&X-Plex-Client-Identifier=watchlistarr"),
       None,
-      Some(parse("""{"feedtype": "watchlist"}""").getOrElse(Json.Null))
+      Some(parse("""{"feedType": "watchlist"}""").getOrElse(Json.Null))
     ).returning(IO.pure(parse(Source.fromResource("rss-feed-generated.json").getLines().mkString("\n")))).anyNumberOfTimes()
     (mockHttpClient.httpRequest _).expects(
       Method.POST,
       Uri.unsafeFromString("https://discover.provider.plex.tv/rss?X-Plex-Token=test-token&X-Plex-Client-Identifier=watchlistarr"),
       None,
-      Some(parse("""{"feedtype": "friendsWatchlist"}""").getOrElse(Json.Null))
+      Some(parse("""{"feedType": "friendsWatchlist"}""").getOrElse(Json.Null))
     ).returning(IO.pure(parse(Source.fromResource("rss-feed-generated.json").getLines().mkString("\n")))).anyNumberOfTimes()
     mockHttpClient
   }

--- a/src/test/scala/configuration/ConfigurationUtilsSpec.scala
+++ b/src/test/scala/configuration/ConfigurationUtilsSpec.scala
@@ -139,18 +139,6 @@ class ConfigurationUtilsSpec extends AnyFlatSpec with Matchers with MockFactory 
     an[IllegalArgumentException] should be thrownBy ConfigurationUtils.create(mockConfigReader, mockHttpClient).unsafeRunSync()
   }
 
-  it should "correctly split multiple RSS watchlists feeds" in {
-
-    val mockConfigReader = createMockConfigReader(plexWatchlists = Some("https://rss.plex.tv/1|https://rss.plex.tv/2"))
-    val mockHttpClient = createMockHttpClient()
-
-    val config = ConfigurationUtils.create(mockConfigReader, mockHttpClient).unsafeRunSync()
-    noException should be thrownBy config
-    config.plexWatchlistUrls shouldBe Set(
-      Uri.unsafeFromString("https://rss.plex.tv/b5adbd07-fc91-4636-b77a-89f34a703473")
-    )
-  }
-
   private def createMockConfigReader(
                                       sonarrApiKey: Option[String] = Some("sonarr-api-key"),
                                       sonarrRootFolder: Option[String] = None,
@@ -158,8 +146,7 @@ class ConfigurationUtilsSpec extends AnyFlatSpec with Matchers with MockFactory 
                                       radarrApiKey: Option[String] = Some("radarr-api-key"),
                                       plexWatchlist1: Option[String] = None,
                                       plexWatchlist2: Option[String] = None,
-                                      plexToken: Option[String] = Some("test-token"),
-                                      plexWatchlists: Option[String] = None
+                                      plexToken: Option[String] = Some("test-token")
                                     ): ConfigurationReader = {
     val unset = None
 
@@ -179,6 +166,7 @@ class ConfigurationUtilsSpec extends AnyFlatSpec with Matchers with MockFactory 
     (mockConfigReader.getConfigOption _).expects(Keys.plexWatchlist2).returning(plexWatchlist2).anyNumberOfTimes()
     (mockConfigReader.getConfigOption _).expects(Keys.sonarrSeasonMonitoring).returning(unset).anyNumberOfTimes()
     (mockConfigReader.getConfigOption _).expects(Keys.plexToken).returning(plexToken).anyNumberOfTimes()
+    (mockConfigReader.getConfigOption _).expects(Keys.skipFriendSync).returning(unset).anyNumberOfTimes()
     mockConfigReader
   }
 

--- a/src/test/scala/configuration/ConfigurationUtilsSpec.scala
+++ b/src/test/scala/configuration/ConfigurationUtilsSpec.scala
@@ -72,6 +72,16 @@ class ConfigurationUtilsSpec extends AnyFlatSpec with Matchers with MockFactory 
     config.sonarrRootFolder shouldBe "/data3"
   }
 
+  it should "find the root folder with an escaped slash provided in sonarr config" in {
+
+    val mockConfigReader = createMockConfigReader(sonarrRootFolder = Some("//data3"))
+    val mockHttpClient = createMockHttpClient()
+
+    val config = ConfigurationUtils.create(mockConfigReader, mockHttpClient).unsafeRunSync()
+    noException should be thrownBy config
+    config.sonarrRootFolder shouldBe "/data3"
+  }
+
   it should "throw an error if the sonarr root folder provided can't be found" in {
 
     val mockConfigReader = createMockConfigReader(sonarrRootFolder = Some("/unknown"))
@@ -104,6 +114,16 @@ class ConfigurationUtilsSpec extends AnyFlatSpec with Matchers with MockFactory 
   it should "find the root folder with a trailing slash provided in radarr config" in {
 
     val mockConfigReader = createMockConfigReader(radarrRootFolder = Some("/data3/"))
+    val mockHttpClient = createMockHttpClient()
+
+    val config = ConfigurationUtils.create(mockConfigReader, mockHttpClient).unsafeRunSync()
+    noException should be thrownBy config
+    config.radarrRootFolder shouldBe "/data3"
+  }
+
+  it should "find the root folder with an escaped slash provided in radarr config" in {
+
+    val mockConfigReader = createMockConfigReader(radarrRootFolder = Some("//data3"))
     val mockHttpClient = createMockHttpClient()
 
     val config = ConfigurationUtils.create(mockConfigReader, mockHttpClient).unsafeRunSync()

--- a/src/test/scala/plex/PlexUtilsSpec.scala
+++ b/src/test/scala/plex/PlexUtilsSpec.scala
@@ -50,7 +50,7 @@ class PlexUtilsSpec extends AnyFlatSpec with Matchers with PlexUtils with MockFa
 
   it should "successfully ping the Plex server" in {
     val mockClient = mock[HttpClient]
-    val config = createConfiguration(Some("test-token"))
+    val config = createConfiguration(Set("test-token"))
     (mockClient.httpRequest _).expects(
       Method.GET,
       Uri.unsafeFromString("https://plex.tv/api/v2/ping?X-Plex-Token=test-token&X-Plex-Client-Identifier=watchlistarr"),
@@ -65,7 +65,7 @@ class PlexUtilsSpec extends AnyFlatSpec with Matchers with PlexUtils with MockFa
 
   it should "successfully fetch the watchlist using the plex token" in {
     val mockClient = mock[HttpClient]
-    val config = createConfiguration(Some("test-token"))
+    val config = createConfiguration(Set("test-token"))
     (mockClient.httpRequest _).expects(
       Method.GET,
       Uri.unsafeFromString("https://metadata.provider.plex.tv/library/sections/watchlist/all?X-Plex-Token=test-token"),
@@ -95,7 +95,7 @@ class PlexUtilsSpec extends AnyFlatSpec with Matchers with PlexUtils with MockFa
 
   it should "successfully fetch friends from Plex" in {
     val mockClient = mock[HttpClient]
-    val config = createConfiguration(Some("test-token"))
+    val config = createConfiguration(Set("test-token"))
     val query = GraphQLQuery(
       """query GetAllFriends {
         |        allFriendsV2 {
@@ -117,13 +117,13 @@ class PlexUtilsSpec extends AnyFlatSpec with Matchers with PlexUtils with MockFa
     eitherResult shouldBe a[Right[_, _]]
     val result = eitherResult.getOrElse(Set.empty[User])
     result.size shouldBe 2
-    result.head shouldBe User("ecdb6as0230e2115", "friend-1")
-    result.last shouldBe User("a31281fd8s413643", "friend-2")
+    result.head shouldBe (User("ecdb6as0230e2115", "friend-1"), "test-token")
+    result.last shouldBe (User("a31281fd8s413643", "friend-2"), "test-token")
   }
 
   it should "successfully fetch a watchlist from a friend on Plex" in {
     val mockClient = mock[HttpClient]
-    val config = createConfiguration(Some("test-token"))
+    val config = createConfiguration(Set("test-token"))
     (mockClient.httpRequest _).expects(
       Method.POST,
       Uri.unsafeFromString("https://community.plex.tv/api"),
@@ -131,7 +131,7 @@ class PlexUtilsSpec extends AnyFlatSpec with Matchers with PlexUtils with MockFa
       *
     ).returning(IO.pure(parse(Source.fromResource("plex-get-watchlist-from-friend.json").getLines().mkString("\n")))).once()
 
-    val eitherResult = getWatchlistIdsForUser(config, mockClient)(User("ecdb6as0230e2115", "friend-1")).value.unsafeRunSync()
+    val eitherResult = getWatchlistIdsForUser(config, mockClient, "test-token")(User("ecdb6as0230e2115", "friend-1")).value.unsafeRunSync()
 
     eitherResult shouldBe a[Right[_, _]]
     val result = eitherResult.getOrElse(Set.empty[TokenWatchlistItem])
@@ -141,7 +141,7 @@ class PlexUtilsSpec extends AnyFlatSpec with Matchers with PlexUtils with MockFa
 
   it should "successfully fetch multiple watchlist pages from a friend on Plex" in {
     val mockClient = mock[HttpClient]
-    val config = createConfiguration(Some("test-token"))
+    val config = createConfiguration(Set("test-token"))
     (mockClient.httpRequest _).expects(
       Method.POST,
       Uri.unsafeFromString("https://community.plex.tv/api"),
@@ -155,7 +155,7 @@ class PlexUtilsSpec extends AnyFlatSpec with Matchers with PlexUtils with MockFa
       *
     ).returning(IO.pure(parse(Source.fromResource("plex-get-watchlist-from-friend.json").getLines().mkString("\n")))).once()
 
-    val eitherResult = getWatchlistIdsForUser(config, mockClient)(User("ecdb6as0230e2115", "friend-1")).value.unsafeRunSync()
+    val eitherResult = getWatchlistIdsForUser(config, mockClient, "test-token")(User("ecdb6as0230e2115", "friend-1")).value.unsafeRunSync()
 
     eitherResult shouldBe a[Right[_, _]]
     val result = eitherResult.getOrElse(Set.empty[TokenWatchlistItem])
@@ -163,7 +163,7 @@ class PlexUtilsSpec extends AnyFlatSpec with Matchers with PlexUtils with MockFa
     result.head shouldBe TokenWatchlistItem("The Twilight Saga: Breaking Dawn - Part 2", "5d77688b9ab54400214e789b", "movie", "/library/metadata/5d77688b9ab54400214e789b")
   }
 
-  private def createConfiguration(plexToken: Option[String]): Configuration = Configuration(
+  private def createConfiguration(plexTokens: Set[String]): Configuration = Configuration(
     refreshInterval = 10.seconds,
     sonarrBaseUrl = Uri.unsafeFromString("https://localhost:8989"),
     sonarrApiKey = "sonarr-api-key",
@@ -176,7 +176,7 @@ class PlexUtilsSpec extends AnyFlatSpec with Matchers with PlexUtils with MockFa
     radarrQualityProfileId = 1,
     radarrRootFolder = "/root/",
     radarrBypassIgnored = false,
-    plexWatchlistUrls = List(Uri.unsafeFromString("https://localhost:9090")),
-    plexToken = plexToken
+    plexWatchlistUrls = Set(Uri.unsafeFromString("https://localhost:9090")),
+    plexTokens = plexTokens
   )
 }

--- a/src/test/scala/plex/PlexUtilsSpec.scala
+++ b/src/test/scala/plex/PlexUtilsSpec.scala
@@ -177,6 +177,7 @@ class PlexUtilsSpec extends AnyFlatSpec with Matchers with PlexUtils with MockFa
     radarrRootFolder = "/root/",
     radarrBypassIgnored = false,
     plexWatchlistUrls = Set(Uri.unsafeFromString("https://localhost:9090")),
-    plexTokens = plexTokens
+    plexTokens = plexTokens,
+    skipFriendSync = false
   )
 }


### PR DESCRIPTION
Found a way to automate RSS feed generation, since the Plex UI no longer lets you do it.

This required a fairly large refactor to make RSS feed URLs no longer mandatory. I threw in a couple of improvements as well while I was at it

Fixes #51 and #56 and #58

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Support for multiple Plex tokens to fetch watchlists.
  - New environment variable "SKIP_FRIEND_SYNC" to customize synchronization behavior.
  - Enhanced search and retrieval of Plex watchlists.
  - Added parsing functionality for RSS feed information.

- **Bug Fixes**
  - Corrected typographical error in documentation from "sneak peak" to "sneak peek."
  - Normalized file paths to handle double slashes.

- **Documentation**
  - Updated feature release information and requirements in the README.
  - Streamlined instructions for adding Plex tokens.
  - Enhanced description of Plex Watchlist methods and support.

- **Refactor**
  - Optimized methods for handling multiple Plex tokens.
  - Improved log message clarity for items not on Plex watchlists.

- **Tests**
  - Added new tests for RSS watchlist feed handling.
  - Adjusted existing tests to accommodate new configurations and token management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->