### PR TITLE
Set maximum memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Running this using native java requires the fat jar, download the latest from th
 java -Dsonarr.apikey=YOUR_API_KEY\
   -Dradarr.apikey=YOUR_API_KEY\
   -Dplex.token=YOUR_PLEX_TOKEN\
+  -Xmx100m\
   -jar watchlistarr.java
 ```
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -2,6 +2,8 @@
 
 CMD="/app/bin/watchlistarr"
 
+JAVA_OPTS="-Xmx100m"
+
 if [ -n "$SONARR_API_KEY" ]; then
   CMD="$CMD -Dsonarr.apikey=$SONARR_API_KEY"
 fi
@@ -66,4 +68,4 @@ if [ -n "$SKIP_FRIEND_SYNC" ]; then
   CMD="$CMD -Dplex.skipfriendsync=$SKIP_FRIEND_SYNC"
 fi
 
-exec $CMD
+exec $CMD $JAVA_OPTS


### PR DESCRIPTION
The docker file is now set to have a maximum memory limit of 100M

Running this natively, this needs to be set via a parameter as well, I have updated the README to reflect how this can be done

Fixes #37 