### PR TITLE
Skip movies and shows without tmdb/tvdb ids

### DIFF
--- a/src/main/scala/WatchlistSync.scala
+++ b/src/main/scala/WatchlistSync.scala
@@ -45,11 +45,21 @@ object WatchlistSync
           logger.debug(s"$c \"${watchlistedItem.title}\" already exists in Sonarr/Radarr")
           Right(IO.unit)
         case (false, "show") =>
-          logger.debug(s"Found show \"${watchlistedItem.title}\" which does not exist yet in Sonarr")
-          Right(addToSonarr(client)(config.sonarrConfiguration)(watchlistedItem))
+          if (watchlistedItem.getTvdbId.isDefined) {
+            logger.debug(s"Found show \"${watchlistedItem.title}\" which does not exist yet in Sonarr")
+            Right(addToSonarr(client)(config.sonarrConfiguration)(watchlistedItem))
+          } else {
+            logger.debug(s"Found show \"${watchlistedItem.title}\" which does not exist yet in Sonarr, but we do not have the tvdb ID so will skip adding")
+            Right(IO.unit)
+          }
         case (false, "movie") =>
-          logger.debug(s"Found movie \"${watchlistedItem.title}\" which does not exist yet in Radarr")
-          Right(addToRadarr(client)(config.radarrConfiguration)(watchlistedItem))
+          if (watchlistedItem.getTmdbId.isDefined) {
+            logger.debug(s"Found movie \"${watchlistedItem.title}\" which does not exist yet in Radarr")
+            Right(addToRadarr(client)(config.radarrConfiguration)(watchlistedItem))
+          } else {
+            logger.debug(s"Found movie \"${watchlistedItem.title}\" which does not exist yet in Radarr, but we do not have the tmdb ID so will skip adding")
+            Right(IO.unit)
+          }
         case (false, c) =>
           logger.warn(s"Found $c \"${watchlistedItem.title}\", but I don't recognize the category")
           Left(new Throwable(s"Unknown category $c"))

--- a/src/test/resources/watchlist-missing-ids.json
+++ b/src/test/resources/watchlist-missing-ids.json
@@ -1,0 +1,943 @@
+{
+  "title" : "Plex Watchlist",
+  "links" : {
+    "self" : "https://rss.plex.tv/REDACTED"
+  },
+  "description" : "Plex watchlist for me",
+  "description" : "Plex watchlist for me",
+  "category" : "My Watchlist",
+  "items" : [
+    {
+      "title" : "Enola Holmes 2 (2022)",
+      "pubDate" : "Mon, 23 Oct 2023 07:58:16 GMT",
+      "link" : "https://watch.plex.tv/movie/enola-holmes-2-2",
+      "guids" : [
+        "imdb://tt14641788"
+      ],
+      "description" : "Now a detective-for-hire, Enola Holmes takes on her first official case to find a missing girl as the sparks of a dangerous conspiracy ignite a mystery that requires the help of friends - and Sherlock himself - to unravel.",
+      "category" : "movie",
+      "credits" : [
+        {
+          "credit" : "Millie Bobby Brown",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Henry Cavill",
+          "role" : "actor"
+        },
+        {
+          "credit" : "David Thewlis",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Louis Partridge",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Susan Wokoma",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Adeel Akhtar",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Sharon Duncan-Brewster",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Helena Bonham Carter",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Sofia Stavrinou",
+          "role" : "actor"
+        },
+        {
+          "credit" : "John Parshall",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Himesh Patel",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Hannah Dodd",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Abbie Hern",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Râ”œâ”‚isâ”œÂ¡n Monaghan",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Gabriel Tierney",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Catriona Chandler",
+          "role" : "actor"
+        },
+        {
+          "credit" : "David Westhead",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Tim McMullan",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Lee Boardman",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Serrana Su-Ling Bliss",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Tony Lucken",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Alessandra Perotto",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Alan Mitchell",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Chris Dunckley",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Lenny Rush",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Alison Knox",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Christopher Saul",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Brahmdeo Shannon Ramana",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Karishma Navekar",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Clive Ward",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Elizabeth Hill",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Nick Raggett",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Sue Graham",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Mark Fleischmann",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Stefan Petermann",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Archie Caswell-Chappell",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Matthew Brazier",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Jules Wallace",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Donovan Louie",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Nia Gandhi",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Alannah Winn-Taylor",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Peter Groom",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Charlie Nicholson",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Eleanor Dang",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Charlotte Robinson",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Katelyn Gray",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Preeti Sian",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Sophia Turner",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Annie Bloomfield",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Hannah Bodenham",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Tabitha Bond",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Callum Bowman",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Miekaile Browne",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Alastair Crosswell",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Rory Cubbin",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Ramzan Miah",
+          "role" : "actor"
+        },
+        {
+          "credit" : "James Berkery",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Andres Quero Marin",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Tyler Rainbow",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Yasmin Riley",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Vanessa Vince-Pang",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Madeleine Waters",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Charlotte Woof",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Cecily Beer",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Sally Alexandra",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Taylor Maclennan",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Cormac Browne",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Mircea Belei",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Boyan Ivanov",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Daniel Pemberton",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Harry Bradbeer",
+          "role" : "director"
+        },
+        {
+          "credit" : "Alex Garcia",
+          "role" : "producer"
+        },
+        {
+          "credit" : "Mary Parent",
+          "role" : "producer"
+        },
+        {
+          "credit" : "Millie Bobby Brown",
+          "role" : "producer"
+        },
+        {
+          "credit" : "Ali Mendes",
+          "role" : "producer"
+        },
+        {
+          "credit" : "Paige Brown",
+          "role" : "producer"
+        },
+        {
+          "credit" : "Jack Thorne",
+          "role" : "writer"
+        }
+      ],
+      "thumbnail" : {
+        "url" : "https://images.plex.tv/photo?url=https%3A%2F%2Fimage.tmdb.org%2Ft%2Fp%2Foriginal%2FtegBpjM5ODoYoM1NjaiHVLEA0QM.jpg"
+      },
+      "keywords" : [
+        "mystery",
+        "action",
+        "adventure",
+        "crime",
+        "drama",
+        "comedy",
+        "history"
+      ],
+      "rating" : {
+        "rating" : "pg-13",
+        "scheme" : "urn:mpaa"
+      }
+    },
+    {
+      "title" : "Past Lives (2023)",
+      "pubDate" : "Sun, 22 Oct 2023 13:00:43 GMT",
+      "link" : "https://watch.plex.tv/movie/past-lives-3",
+      "guids" : [
+        "imdb://tt13238346"
+      ],
+      "description" : "Nora and Hae Sung, two deeply connected childhood friends, are wrested apart after Nora's family emigrates from South Korea. Twenty years later, they are reunited for one fateful week as they confront notions of love and destiny.",
+      "category" : "movie",
+      "credits" : [
+        {
+          "credit" : "Greta Lee",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Teo Yoo",
+          "role" : "actor"
+        },
+        {
+          "credit" : "John Magaro",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Moon Seung-a",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Yim Seung-min",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Jojo T. Gibbs",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Emily Cass McDonnell",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Federico Rodriguez",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Kristen Sieh",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Yoon Ji-hye",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Conrad Schott",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Choi Won-young",
+          "role" : "actor"
+        },
+        {
+          "credit" : "An Min-yeong",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Seo Yeon-woo",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Hwang Seung-eon",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Chang Ki-ha",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Shin Hee-cheol",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Chase Sui Wonders",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Isaac Powell",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Celine Song",
+          "role" : "director"
+        },
+        {
+          "credit" : "Christine Vachon",
+          "role" : "producer"
+        },
+        {
+          "credit" : "Pamela Koffler",
+          "role" : "producer"
+        },
+        {
+          "credit" : "David Hinojosa",
+          "role" : "producer"
+        },
+        {
+          "credit" : "Celine Song",
+          "role" : "writer"
+        }
+      ],
+      "thumbnail" : {
+        "url" : "https://images.plex.tv/photo?url=https%3A%2F%2Fimage.tmdb.org%2Ft%2Fp%2Foriginal%2FrzO71VFu7CpJMfF5TQNMj0d1lSV.jpg"
+      },
+      "keywords" : [
+        "drama",
+        "romance"
+      ],
+      "rating" : {
+        "rating" : "pg-13",
+        "scheme" : "urn:mpaa"
+      }
+    },
+    {
+      "title" : "Taylor Swift: The Eras Tour (2023)",
+      "pubDate" : "Thu, 19 Oct 2023 17:25:32 GMT",
+      "link" : "https://watch.plex.tv/movie/taylor-swift-the-eras-tour-movie",
+      "guids" : [
+        "imdb://tt28814949"
+      ],
+      "description" : "The cultural phenomenon continues on the big screen! Immerse yourself in this once-in-a-lifetime concert film experience with a breathtaking, cinematic view of the history-making tour. Taylor Swift Eras attire and friendship bracelets are strongly encouraged!",
+      "category" : "movie",
+      "credits" : [
+        {
+          "credit" : "Taylor Swift",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Mike Meadows",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Max Bernstein",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Paul Sidoti",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Amos Heller",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Matt Billingslea",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Karina DePiano",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Melanie Nyema",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Kamilah Marshall",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Jeslyn Gorman",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Eliotte Woodford",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Amanda Balen",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Natalie Reid",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Tori Evans",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Raphael Thomas",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Audrey Douglass",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Kevin Scheitzbach",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Jan Ravnik",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Kameron Saunders",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Taylor Banks",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Natalie Peterson",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Sydney Moss",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Tamiya Lewis",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Natalie Lecznar",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Sam McWilliams",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Whyley Yoshimura",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Karen Chuang",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Sam Wrench",
+          "role" : "director"
+        },
+        {
+          "credit" : "Taylor Swift",
+          "role" : "producer"
+        },
+        {
+          "credit" : "Ethan Tobman",
+          "role" : "writer"
+        }
+      ],
+      "thumbnail" : {
+        "url" : "https://images.plex.tv/photo?url=https%3A%2F%2Fimage.tmdb.org%2Ft%2Fp%2Foriginal%2Fa5EreVlyB9fXzZ2Rf9ugOLrW5YI.jpg"
+      },
+      "keywords" : [
+        "music",
+        "documentary",
+        "musical"
+      ],
+      "rating" : {
+        "rating" : "pg-13",
+        "scheme" : "urn:mpaa"
+      }
+    },
+    {
+      "title" : "The Great (2020)",
+      "pubDate" : "Sat, 07 Oct 2023 10:06:12 GMT",
+      "link" : "https://watch.plex.tv/show/the-great",
+      "guids" : [
+        "imdb://tt2235759"
+      ],
+      "description" : "A genre-bending, anti-historical ride through 18th century Russia following the rise of Catherine the Nothing to Catherine the Great and her explosive relationship with husband Peter, the emperor of Russia.",
+      "category" : "show",
+      "credits" : [
+        {
+          "credit" : "Elle Fanning",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Phoebe Fox",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Gwilym Lee",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Adam Godley",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Douglas Hodge",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Belinda Bromilow",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Bayo Gbadamosi",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Nicholas Hoult",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Florence Keith-Roach",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Charity Wakefield",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Sacha Dhawan",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Grace Molony",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Freddie Fox",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Danusia Samal",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Sebastian de Souza",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Louis Hynes",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Kemi-Bo Jacobs",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Christophe Tek",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Jamie Demetriou",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Alistair Green",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Jordan Kagaba",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Charlie Price",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Stewart Scudamore",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Ezra Faroque Khan",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Asheq Akhtar",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Blake Harrison",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Grace Chilton",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Abraham Popoola",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Richard Pyros",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Tristan Beint",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Dustin Demri-Burns",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Ashwin Bolar",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Henry Meredith",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Liv Hill",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Liam Fleming",
+          "role" : "actor"
+        },
+        {
+          "credit" : "John Sessions",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Mark Ramsay",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Miles Jupp",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Christianne Oliveira",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Daniel Tuite",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Dan Wyllie",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Natalie Dew",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Waleed Akhtar",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Komal Amin",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Lorenzo Vigevano",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Raphael Sowole",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Geoff Bell",
+          "role" : "actor"
+        },
+        {
+          "credit" : "James Smith",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Scott Karim",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Julian Barratt",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Ali Ariaie",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Jane Mahady",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Anthony Cozens",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Tom Gaskin",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Toto Bruin",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Tarik Badwan",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Keon Martial-Phillip",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Max Boast",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Billy Postlethwaite",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Franck Assi",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Osian Roberts",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Bill Bekele",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Sam Coulson",
+          "role" : "actor"
+        },
+        {
+          "credit" : "James McNicholas",
+          "role" : "actor"
+        },
+        {
+          "credit" : "Colin Bucksey",
+          "role" : "director"
+        },
+        {
+          "credit" : "Bertie",
+          "role" : "director"
+        },
+        {
+          "credit" : "Bert",
+          "role" : "director"
+        },
+        {
+          "credit" : "Zetna Fuentes",
+          "role" : "director"
+        },
+        {
+          "credit" : "Ally Pankiw",
+          "role" : "director"
+        },
+        {
+          "credit" : "Ben Chessell",
+          "role" : "director"
+        },
+        {
+          "credit" : "Geeta Patel",
+          "role" : "director"
+        },
+        {
+          "credit" : "Matt Shakman",
+          "role" : "director"
+        },
+        {
+          "credit" : "Dean O'Toole",
+          "role" : "producer"
+        },
+        {
+          "credit" : "Nick O'Hagan",
+          "role" : "producer"
+        },
+        {
+          "credit" : "Gretel Vella",
+          "role" : "writer"
+        },
+        {
+          "credit" : "James Wood",
+          "role" : "writer"
+        },
+        {
+          "credit" : "Tess Morris",
+          "role" : "writer"
+        }
+      ],
+      "thumbnail" : {
+        "url" : "https://images.plex.tv/photo?url=https%3A%2F%2Fimage.tmdb.org%2Ft%2Fp%2Foriginal%2Ftpz9UQ3hUwYufNcKWVW00FCjWyc.jpg"
+      },
+      "keywords" : [
+        "drama",
+        "comedy",
+        "biography",
+        "history"
+      ],
+      "rating" : {
+        "rating" : "tv-ma",
+        "scheme" : "urn:v-chip"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #70 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved content identification by adding checks for TVDB and TMDB IDs during synchronization with Sonarr and Radarr.

- **Bug Fixes**
  - Fixed an issue where items without proper IDs could be incorrectly added to Sonarr or Radarr.

- **Tests**
  - Added a new test case to verify that shows and movies without IDs are skipped during the sync process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->