### PR TITLE
Skip metadata that cannot be fetched

### DIFF
--- a/src/main/scala/configuration/ConfigurationRedactor.scala
+++ b/src/main/scala/configuration/ConfigurationRedactor.scala
@@ -1,0 +1,37 @@
+package configuration
+
+object ConfigurationRedactor {
+  def redactToString(config: Configuration): String = {
+    s"""
+      |Configuration:
+      |  refreshInterval: ${config.refreshInterval.toSeconds} seconds
+      |
+      |  SonarrConfiguration:
+      |    sonarrBaseUrl: ${config.sonarrConfiguration.sonarrBaseUrl}
+      |    sonarrApiKey: REDACTED
+      |    sonarrQualityProfileId: ${config.sonarrConfiguration.sonarrQualityProfileId}
+      |    sonarrRootFolder: ${config.sonarrConfiguration.sonarrRootFolder}
+      |    sonarrBypassIgnored: ${config.sonarrConfiguration.sonarrBypassIgnored}
+      |    sonarrLanguageProfileId: ${config.sonarrConfiguration.sonarrLanguageProfileId}
+      |
+      |  RadarrConfiguration:
+      |    radarrBaseUrl: ${config.radarrConfiguration.radarrBaseUrl}
+      |    radarrApiKey: REDACTED
+      |    radarrQualityProfileId: ${config.radarrConfiguration.radarrQualityProfileId}
+      |    radarrRootFolder: ${config.radarrConfiguration.radarrRootFolder}
+      |    radarrBypassIgnored: ${config.radarrConfiguration.radarrBypassIgnored}
+      |
+      |  PlexConfiguration:
+      |    plexWatchlistUrls: ${config.plexConfiguration.plexWatchlistUrls.mkString(", ")}
+      |    plexTokens: ${config.plexConfiguration.plexTokens.map(_ => "REDACTED").mkString(", ")}
+      |    skipFriendSync: ${config.plexConfiguration.skipFriendSync}
+      |
+      |  DeleteConfiguration:
+      |    movieDeleting: ${config.deleteConfiguration.movieDeleting}
+      |    endedShowDeleting: ${config.deleteConfiguration.endedShowDeleting}
+      |    continuingShowDeleting: ${config.deleteConfiguration.continuingShowDeleting}
+      |    deleteInterval: ${config.deleteConfiguration.deleteInterval.toDays} days
+      |
+      |""".stripMargin
+  }
+}

--- a/src/main/scala/configuration/ConfigurationUtils.scala
+++ b/src/main/scala/configuration/ConfigurationUtils.scala
@@ -65,7 +65,7 @@ object ConfigurationUtils {
     )
 
     config.map { c =>
-      logger.info(s"Configuration read by Watchlistarr: ${c.asJson.spaces2}")
+      logger.info(ConfigurationRedactor.redactToString(c))
       c
     }
   }

--- a/src/main/scala/configuration/ConfigurationUtils.scala
+++ b/src/main/scala/configuration/ConfigurationUtils.scala
@@ -4,6 +4,7 @@ import cats.effect.IO
 import cats.implicits.toTraverseOps
 import http.HttpClient
 import io.circe.generic.auto._
+import io.circe.syntax._
 import io.circe.Json
 import org.http4s.{Method, Uri}
 import org.slf4j.LoggerFactory
@@ -64,7 +65,7 @@ object ConfigurationUtils {
     )
 
     config.map { c =>
-      logger.info(s"Configuration read by Watchlistarr: $c")
+      logger.info(s"Configuration read by Watchlistarr: ${c.asJson.spaces2}")
       c
     }
   }


### PR DESCRIPTION
Thanks to a redditor, I've found a bug where Plex will return a 404 for some metadata, and no matter what you try, you cannot delete it off your watchlist.

This should give some partial relief to that, by skipping the items that are causing issues. It will still attempt to sync everything else.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved error handling and operation sequencing in backend utilities for enhanced stability and performance.

- **Tests**
	- Added new test cases to ensure reliable fetching of user watchlists, including scenarios where items are not found, enhancing the robustness of the feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->