### PR TITLE
Graceful handling of non-plex pass users

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ upon startup of the app, where the logs will list the movies/tv shows that are o
 
 ### Requirements
 
-* Plex Pass Subscription (For those not wanting to get a Plex Pass, see the section below on Plex Pass alternative)
+* Plex Pass Subscription (Recommended, otherwise see "Plex Pass Alternative" section below)
 * Sonarr v3 or higher
 * Radarr v3 or higher
 * Friends' Watchlists [Account Visibility](https://app.plex.tv/desktop/#!/settings/account) must be changed to 'Friends
@@ -119,7 +119,7 @@ The Plex Pass subscription is required to generate the RSS Feed URLs. Without a 
 
 If the app detects that you are not a Plex Pass user (i.e. the app tries to generate an RSS URL, and it fails), it will fall back into a periodic sync.
 
-The periodic sync will run every 21 minutes, ignoring the configuration for REFRESH_INTERVAL_SECONDS
+The periodic sync will run every 19 minutes, ignoring the configuration for REFRESH_INTERVAL_SECONDS
 
 All other settings will still be valid
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ upon startup of the app, where the logs will list the movies/tv shows that are o
 
 ### Requirements
 
-* Plex Pass Subscription
+* Plex Pass Subscription (For those not wanting to get a Plex Pass, see the section below on Plex Pass alternative)
 * Sonarr v3 or higher
 * Radarr v3 or higher
 * Friends' Watchlists [Account Visibility](https://app.plex.tv/desktop/#!/settings/account) must be changed to 'Friends
@@ -113,6 +113,15 @@ in [entrypoint.sh](https://github.com/nylonee/watchlistarr/blob/main/docker/entr
 | ALLOW_ENDED_SHOW_DELETING      | false                 | Boolean flag to enable/disable the full Watchlistarr sync for ended shows. If enabled, shows that have no more planned seasons and are not watchlisted will be deleted from Sonarr                  |
 | ALLOW_CONTINUING_SHOW_DELETING | false                 | Boolean flag to enable/disable the full Watchlistarr sync for continuing shows. If enabled, shows that still have planned seasons and are not watchlisted will be deleted from Sonarr               |
 | DELETE_INTERVAL_DAYS           | 7                     | Number of days to wait before deleting content from the arrs (Deleting must be enabled)                                                                                                             |
+
+## Plex Pass Alternative
+The Plex Pass subscription is required to generate the RSS Feed URLs. Without a Plex Pass, the normal API calls are too heavy-hitting on Plex's servers.
+
+If the app detects that you are not a Plex Pass user (i.e. the app tries to generate an RSS URL, and it fails), it will fall back into a periodic sync.
+
+The periodic sync will run every 21 minutes, ignoring the configuration for REFRESH_INTERVAL_SECONDS
+
+All other settings will still be valid
 
 ## Developers Corner
 

--- a/src/main/scala/PlexTokenSync.scala
+++ b/src/main/scala/PlexTokenSync.scala
@@ -14,19 +14,22 @@ object PlexTokenSync extends PlexUtils with SonarrUtils with RadarrUtils {
   private val logger = LoggerFactory.getLogger(getClass)
 
   def run(config: Configuration, client: HttpClient, firstRun: Boolean): IO[Unit] = {
+    val runTokenSync = firstRun || !config.plexConfiguration.hasPlexPass
+
     val result = for {
-      selfWatchlist <- if (firstRun)
+      selfWatchlist <- if (runTokenSync)
         getSelfWatchlist(config.plexConfiguration, client)
       else
         EitherT.pure[IO, Throwable](Set.empty[Item])
-      _ = if (firstRun) logger.info(s"Found ${selfWatchlist.size} items on user's watchlist using the plex token")
-      othersWatchlist <- if (!firstRun || config.plexConfiguration.skipFriendSync)
+      _ = if (runTokenSync)
+        logger.info(s"Found ${selfWatchlist.size} items on user's watchlist using the plex token")
+      othersWatchlist <- if (config.plexConfiguration.skipFriendSync || !runTokenSync)
         EitherT.pure[IO, Throwable](Set.empty[Item])
       else
         getOthersWatchlist(config.plexConfiguration, client)
       watchlistDatas <- EitherT[IO, Throwable, List[Set[Item]]](config.plexConfiguration.plexWatchlistUrls.map(fetchWatchlistFromRss(client)).toList.sequence.map(Right(_)))
       watchlistData = watchlistDatas.flatten.toSet
-      _ = if (firstRun) logger.info(s"Found ${othersWatchlist.size} items on other available watchlists using the plex token")
+      _ = if (runTokenSync) logger.info(s"Found ${othersWatchlist.size} items on other available watchlists using the plex token")
       movies <- fetchMovies(client)(config.radarrConfiguration.radarrApiKey, config.radarrConfiguration.radarrBaseUrl, config.radarrConfiguration.radarrBypassIgnored)
       series <- fetchSeries(client)(config.sonarrConfiguration.sonarrApiKey, config.sonarrConfiguration.sonarrBaseUrl, config.sonarrConfiguration.sonarrBypassIgnored)
       allIds = movies ++ series

--- a/src/main/scala/configuration/Configuration.scala
+++ b/src/main/scala/configuration/Configuration.scala
@@ -33,7 +33,8 @@ case class RadarrConfiguration(
 case class PlexConfiguration(
                               plexWatchlistUrls: Set[Uri],
                               plexTokens: Set[String],
-                              skipFriendSync: Boolean
+                              skipFriendSync: Boolean,
+                              hasPlexPass: Boolean
                             )
 
 case class DeleteConfiguration(

--- a/src/main/scala/configuration/ConfigurationRedactor.scala
+++ b/src/main/scala/configuration/ConfigurationRedactor.scala
@@ -25,6 +25,7 @@ object ConfigurationRedactor {
       |    plexWatchlistUrls: ${config.plexConfiguration.plexWatchlistUrls.mkString(", ")}
       |    plexTokens: ${config.plexConfiguration.plexTokens.map(_ => "REDACTED").mkString(", ")}
       |    skipFriendSync: ${config.plexConfiguration.skipFriendSync}
+      |    hasPlexPass: ${config.plexConfiguration.hasPlexPass}
       |
       |  DeleteConfiguration:
       |    movieDeleting: ${config.deleteConfiguration.movieDeleting}

--- a/src/main/scala/configuration/ConfigurationUtils.scala
+++ b/src/main/scala/configuration/ConfigurationUtils.scala
@@ -252,7 +252,7 @@ object ConfigurationUtils {
 
     client.httpRequest(Method.POST, url, None, Some(body)).map {
       case Left(err) =>
-        logger.warn(s"Unable to generate an RSS feed. Do you have an active Plex Pass subscription? Error: $err")
+        logger.warn(s"Unable to generate an RSS feed: $err")
         None
       case Right(json) =>
         logger.debug("Got a result from Plex when generating RSS feed, attempting to decode")

--- a/src/main/scala/configuration/ConfigurationUtils.scala
+++ b/src/main/scala/configuration/ConfigurationUtils.scala
@@ -195,8 +195,11 @@ object ConfigurationUtils {
     watchlistsFromTokenIo.map { watchlistsFromToken =>
       (watchlistsFromConfigDeprecated ++ watchlistsFromToken).toList match {
         case Nil =>
-          throwError("Missing plex watchlist URL")
-        case other => other.map(toPlexUri).toSet
+          logger.warn("Missing RSS URL. Are you an active Plex Pass user?")
+          logger.warn("Real-time RSS sync disabled")
+          Set.empty
+        case other =>
+          other.map(toPlexUri).toSet
       }
     }
   }
@@ -247,7 +250,7 @@ object ConfigurationUtils {
 
     client.httpRequest(Method.POST, url, None, Some(body)).map {
       case Left(err) =>
-        logger.warn(s"Unable to generate an RSS feed: $err")
+        logger.warn(s"Unable to generate an RSS feed. Do you have an active Plex Pass subscription? Error: $err")
         None
       case Right(json) =>
         logger.debug("Got a result from Plex when generating RSS feed, attempting to decode")

--- a/src/main/scala/configuration/ConfigurationUtils.scala
+++ b/src/main/scala/configuration/ConfigurationUtils.scala
@@ -33,8 +33,9 @@ object ConfigurationUtils {
       deleteEndedShows = configReader.getConfigOption(Keys.deleteEndedShow).flatMap(_.toBooleanOption).getOrElse(false)
       deleteContinuingShows = configReader.getConfigOption(Keys.deleteContinuingShow).flatMap(_.toBooleanOption).getOrElse(false)
       deleteInterval = configReader.getConfigOption(Keys.deleteIntervalDays).flatMap(_.toIntOption).getOrElse(7).days
+      hasPlexPass = plexWatchlistUrls.nonEmpty
     } yield Configuration(
-      refreshInterval,
+      if (hasPlexPass) refreshInterval else 19.minutes,
       SonarrConfiguration(
         sonarrBaseUrl,
         sonarrApiKey,
@@ -54,7 +55,8 @@ object ConfigurationUtils {
       PlexConfiguration(
         plexWatchlistUrls,
         plexTokens,
-        skipFriendSync
+        skipFriendSync,
+        hasPlexPass
       ),
       DeleteConfiguration(
         deleteMovies,

--- a/src/test/scala/PlexTokenSyncSpec.scala
+++ b/src/test/scala/PlexTokenSyncSpec.scala
@@ -53,7 +53,8 @@ class PlexTokenSyncSpec extends AnyFlatSpec with Matchers with MockFactory {
     PlexConfiguration(
       plexWatchlistUrls = Set(),
       plexTokens = plexTokens,
-      skipFriendSync = false
+      skipFriendSync = false,
+      hasPlexPass = true
     ),
     DeleteConfiguration(
       movieDeleting = false,

--- a/src/test/scala/configuration/ConfigurationUtilsSpec.scala
+++ b/src/test/scala/configuration/ConfigurationUtilsSpec.scala
@@ -8,9 +8,7 @@ import org.http4s.{Method, Uri}
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import io.circe.generic.auto._
 import io.circe.parser._
-import io.circe.syntax.EncoderOps
 
 import scala.io.Source
 

--- a/src/test/scala/plex/PlexUtilsSpec.scala
+++ b/src/test/scala/plex/PlexUtilsSpec.scala
@@ -194,6 +194,7 @@ class PlexUtilsSpec extends AnyFlatSpec with Matchers with PlexUtils with MockFa
   private def createConfiguration(plexTokens: Set[String]): PlexConfiguration = PlexConfiguration(
     plexWatchlistUrls = Set(Uri.unsafeFromString("https://localhost:9090")),
     plexTokens = plexTokens,
-    skipFriendSync = false
+    skipFriendSync = false,
+    hasPlexPass = true
   )
 }


### PR DESCRIPTION
This closes #73 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an alternative for generating RSS Feed URLs for non-Plex Pass users, allowing periodic sync.
- **Enhancements**
	- Improved app behavior and settings for users without a Plex Pass.
- **Refactor**
	- Adjusted logging and conditional logic in `PlexTokenSync` to support new syncing capabilities.
	- Updated configuration handling to include Plex Pass status.
- **Documentation**
	- Updated README to reflect new functionality and settings adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->