### PR TITLE
Bugfix: Watchlists larger than 300 items will now work

### DIFF
--- a/src/main/scala/plex/MediaContainer.scala
+++ b/src/main/scala/plex/MediaContainer.scala
@@ -1,3 +1,3 @@
 package plex
 
-private[plex] case class MediaContainer(Metadata: List[TokenWatchlistItem])
+private[plex] case class MediaContainer(Metadata: List[TokenWatchlistItem], totalSize: Int)

--- a/src/main/scala/plex/PlexUtils.scala
+++ b/src/main/scala/plex/PlexUtils.scala
@@ -49,17 +49,22 @@ trait PlexUtils {
     }
   }.toList.sequence.map(_ => ())
 
-  protected def getSelfWatchlist(config: PlexConfiguration, client: HttpClient): EitherT[IO, Throwable, Set[Item]] = config.plexTokens.map { token =>
+  protected def getSelfWatchlist(config: PlexConfiguration, client: HttpClient, containerStart: Int = 0): EitherT[IO, Throwable, Set[Item]] = config.plexTokens.map { token =>
+    val containerSize = 300
     val url = Uri
       .unsafeFromString("https://metadata.provider.plex.tv/library/sections/watchlist/all")
       .withQueryParam("X-Plex-Token", token)
-      .withQueryParam("X-Plex-Container-Start", 0) // todo: pagination
-      .withQueryParam("X-Plex-Container-Size", 300)
+      .withQueryParam("X-Plex-Container-Start", containerStart)
+      .withQueryParam("X-Plex-Container-Size", containerSize)
 
     for {
       response <- EitherT(client.httpRequest(Method.GET, url))
       result <- EitherT(response.as[TokenWatchlist].map(toItems(config, client)).sequence).leftMap(err => new Throwable(err))
-    } yield result
+      nextPage <- if (result.size == containerSize)
+        getSelfWatchlist(config, client, containerStart + containerSize)
+      else
+        EitherT.pure[IO, Throwable](Set.empty[Item])
+    } yield result ++ nextPage
   }.toList.sequence.map(_.toSet.flatten)
 
   protected def getOthersWatchlist(config: PlexConfiguration, client: HttpClient): EitherT[IO, Throwable, Set[Item]] =


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the watchlist retrieval process to support pagination, allowing users to fetch their watchlist items in batches for improved performance and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->