### PR TITLE
bump versions and enable fat jar creation

### DIFF
--- a/.github/workflows/release-java.yml
+++ b/.github/workflows/release-java.yml
@@ -28,7 +28,6 @@ jobs:
       - name: sbt validation
         run: sbt "dependencyUpdatesFailBuild; unusedCompileDependenciesTest; undeclaredCompileDependenciesTest; test"
       - name: Build fat JAR
-        if: startsWith(github.ref, 'refs/tags/')
         run: sbt assembly
       - name: Rename fat JAR
         if: startsWith(github.ref, 'refs/tags/')

--- a/build.sbt
+++ b/build.sbt
@@ -18,8 +18,8 @@ val logbackVersion = "1.4.11"
 val scalamockVersion = "5.2.0"
 val scalatestVersion = "3.2.17"
 val shapelessVersion = "2.3.10"
-val slf4jVersion = "2.0.9"
-val snakeYamlVersion = "2.0"
+val slf4jVersion = "2.0.12"
+val snakeYamlVersion = "2.2"
 val vaultVersion = "3.5.0"
 
 libraryDependencies ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -51,6 +51,7 @@ enablePlugins(JavaAppPackaging)
 
 ThisBuild / assemblyMergeStrategy := {
   case "module-info.class" => MergeStrategy.discard
+  case PathList("META-INF", _*) => MergeStrategy.discard
   case x =>
     val oldStrategy = (ThisBuild / assemblyMergeStrategy).value
     oldStrategy(x)


### PR DESCRIPTION
The last version of watchlistarr failed to build jar versions. This PR is to attempt to fix it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
	- Updated logging and YAML parsing libraries to newer versions for improved stability and performance.
- **Refactor**
	- Modified the build process to always include a step for creating a comprehensive application package, ensuring consistency across releases.
- **New Features**
	- Enhanced the workflow to ensure the "Build fat JAR" step runs consistently regardless of the tag reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->