### PR TITLE
Fix for empty metadata bug

### DIFF
--- a/src/main/scala/plex/MediaContainer.scala
+++ b/src/main/scala/plex/MediaContainer.scala
@@ -1,3 +1,3 @@
 package plex
 
-private[plex] case class MediaContainer(Metadata: List[TokenWatchlistItem], totalSize: Int)
+private[plex] case class MediaContainer(Metadata: List[TokenWatchlistItem] = List.empty, totalSize: Int)

--- a/src/test/resources/empty-watchlist-from-token.json
+++ b/src/test/resources/empty-watchlist-from-token.json
@@ -1,0 +1,10 @@
+{
+  "MediaContainer": {
+    "librarySectionID": "watchlist",
+    "librarySectionTitle": "Watchlist",
+    "offset": 300,
+    "totalSize": 16,
+    "identifier": "tv.plex.provider.discover",
+    "size": 0
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Media containers now initialize with an empty list of metadata by default, enhancing the handling of media items with no associated metadata.
- **Tests**
	- Added a test case to ensure that an empty watchlist can be correctly fetched and handled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->