### PR TITLE
Docker: Add .dockerignore to setup clean workspace for docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+# https://docs.docker.com/engine/reference/builder/#dockerignore-file
+/*
+!/build.sbt
+!/docker/entrypoint.sh
+!/project
+!/src


### PR DESCRIPTION
This improves local rebuilds cache if unrelated files are changed.

For example modifying `entrypoint.sh` does not invalidate rebuild of java sources.