### PR TITLE
Ignore scalafmt commit during git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,8 @@
+# The commits that did automated reformatting. You can ignore them
+# during git-blame with `--ignore-rev` or `--ignore-revs-file`.
+#
+#   $ git config --add 'blame.ignoreRevsFile' '.git-blame-ignore-revs'
+#
+
+# Initial run of Scalafmt
+80ce086ea56d2f711f04918617af6833dd1ab8d3


### PR DESCRIPTION
## Description
Add a `.git-blame-ignore-revs` file to ignore scalafmt during git blame.

This works natively on github, and can be configured locally too

## Checklist
- [ ] Documentation Updated
- [ ] `sbt scalafmtAll` Run (and optionally `sbt scalafmtSbt`)
- [ ] At least one approval from a codeowner
