### PR TITLE
Add Support for ARM64

### DIFF
--- a/.github/workflows/docker-alpha.yml
+++ b/.github/workflows/docker-alpha.yml
@@ -15,8 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up environment
-        run: echo "DOCKER_TAG=$(date +%s)" >> $GITHUB_ENV
 
       - name: Docker Metadata action
         id: meta
@@ -27,8 +25,6 @@ jobs:
           tags: |
             type=sha
             alpha
-          labels: |
-            VERSION="${{ github.event.inputs.DOCKER_TAG }}"
 
       - name: Docker Setup QEMU
         uses: docker/setup-qemu-action@v2.1.0

--- a/.github/workflows/docker-alpha.yml
+++ b/.github/workflows/docker-alpha.yml
@@ -39,7 +39,7 @@ jobs:
           buildkitd-flags: --debug
 
       - name: Login to DockerHub
-        uses: docker/login-action@v2.1.0
+        uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/docker-alpha.yml
+++ b/.github/workflows/docker-alpha.yml
@@ -9,6 +9,7 @@ env:
   DOCKER_FILE: docker/Dockerfile
   DOCKER_PLATFORMS: "linux/arm64/v8,linux/amd64"
 
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -17,6 +18,17 @@ jobs:
       - name: Set up environment
         run: echo "DOCKER_TAG=$(date +%s)" >> $GITHUB_ENV
 
+      - name: Docker Metadata action
+        id: meta
+        uses: docker/metadata-action@v4.3.0
+        with:
+          images: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.APP_NAME }}
+          tags: |
+            ${{ github.event.inputs.DOCKER_TAG }}
+            alpha
+          labels: |
+            VERSION="${{ github.event.inputs.DOCKER_TAG }}"
 
       - name: Docker Setup QEMU
         uses: docker/setup-qemu-action@v2.1.0
@@ -39,5 +51,5 @@ jobs:
           file: ${{ env.DOCKER_FILE }}
           platforms: ${{ env.DOCKER_PLATFORMS }}
           push: true
-          tags: ${DOCKER_TAG},alpha
-          labels: VERSION=${DOCKER_TAG}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-alpha.yml
+++ b/.github/workflows/docker-alpha.yml
@@ -16,6 +16,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Docker Metadata action
         id: meta
         uses: docker/metadata-action@v4.3.0
@@ -33,12 +39,6 @@ jobs:
         uses: docker/setup-buildx-action@v2.5.0
         with:
           buildkitd-flags: --debug
-
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push Docker images
         uses: docker/build-push-action@v4.0.0

--- a/.github/workflows/docker-alpha.yml
+++ b/.github/workflows/docker-alpha.yml
@@ -4,26 +4,40 @@ on:
   pull_request:
     branches: [ "main" ]
 
+env:
+  APP_NAME: watchlistarr
+  DOCKER_FILE: docker/Dockerfile
+  DOCKER_PLATFORMS: "linux/arm64/v8,linux/amd64"
+
 jobs:
-
   build:
-
     runs-on: ubuntu-latest
-
-
     steps:
       - uses: actions/checkout@v3
       - name: Set up environment
         run: echo "DOCKER_TAG=$(date +%s)" >> $GITHUB_ENV
+
+
+      - name: Docker Setup QEMU
+        uses: docker/setup-qemu-action@v2.1.0
+    
+      - name: Docker Setup Buildx
+        uses: docker/setup-buildx-action@v2.5.0
+        with:
+          buildkitd-flags: --debug
+
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2.1.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build the Docker image
-        run: docker build . --file docker/Dockerfile --tag nylonee/watchlistarr:${DOCKER_TAG} --label=VERSION=${DOCKER_TAG}
-      - name: Push Docker image
-        run: |
-          docker tag nylonee/watchlistarr:${DOCKER_TAG} nylonee/watchlistarr:alpha
-          docker push nylonee/watchlistarr:${DOCKER_TAG}
-          docker push nylonee/watchlistarr:alpha
+
+      - name: Build and push Docker images
+        uses: docker/build-push-action@v4.0.0
+        with:
+          context: .
+          file: ${{ env.DOCKER_FILE }}
+          platforms: ${{ env.DOCKER_PLATFORMS }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${DOCKER_TAG},alpha
+          labels: VERSION=${DOCKER_TAG}

--- a/.github/workflows/docker-alpha.yml
+++ b/.github/workflows/docker-alpha.yml
@@ -38,6 +38,6 @@ jobs:
           context: .
           file: ${{ env.DOCKER_FILE }}
           platforms: ${{ env.DOCKER_PLATFORMS }}
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           tags: ${DOCKER_TAG},alpha
           labels: VERSION=${DOCKER_TAG}

--- a/.github/workflows/docker-alpha.yml
+++ b/.github/workflows/docker-alpha.yml
@@ -25,7 +25,7 @@ jobs:
           images: |
             ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.APP_NAME }}
           tags: |
-            ${{ github.event.inputs.DOCKER_TAG }}
+            type=sha
             alpha
           labels: |
             VERSION="${{ github.event.inputs.DOCKER_TAG }}"

--- a/.github/workflows/docker-beta.yml
+++ b/.github/workflows/docker-beta.yml
@@ -8,15 +8,13 @@ env:
   APP_NAME: watchlistarr
   DOCKER_FILE: docker/Dockerfile
   DOCKER_PLATFORMS: "linux/arm64/v8,linux/amd64"
+  DOCKER_TAG: $(date +%s)
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up environment
-        run: echo "DOCKER_TAG=$(date +%s)" >> $GITHUB_ENV
-
 
       - name: Docker Setup QEMU
         uses: docker/setup-qemu-action@v2.1.0
@@ -39,5 +37,5 @@ jobs:
           file: ${{ env.DOCKER_FILE }}
           platforms: ${{ env.DOCKER_PLATFORMS }}
           push: true
-          tags: ${DOCKER_TAG},beta
-          labels: VERSION=${DOCKER_TAG}
+          tags: ${{env.DOCKER_TAG}},beta
+          labels: VERSION=${{env.DOCKER_TAG}}

--- a/.github/workflows/docker-beta.yml
+++ b/.github/workflows/docker-beta.yml
@@ -17,6 +17,17 @@ jobs:
       - name: Set up environment
         run: echo "DOCKER_TAG=$(date +%s)" >> $GITHUB_ENV
 
+      - name: Docker Metadata action
+        id: meta
+        uses: docker/metadata-action@v4.3.0
+        with:
+          images: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.APP_NAME }}
+          tags: |
+            ${{ github.event.inputs.DOCKER_TAG }}
+            beta
+          labels: |
+            VERSION="${{ github.event.inputs.DOCKER_TAG }}"
 
       - name: Docker Setup QEMU
         uses: docker/setup-qemu-action@v2.1.0
@@ -39,5 +50,5 @@ jobs:
           file: ${{ env.DOCKER_FILE }}
           platforms: ${{ env.DOCKER_PLATFORMS }}
           push: true
-          tags: ${{ github.event.inputs.DOCKER_TAG }},beta
-          labels: VERSION="${{ github.event.inputs.DOCKER_TAG }}"
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-beta.yml
+++ b/.github/workflows/docker-beta.yml
@@ -14,8 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up environment
-        run: echo "DOCKER_TAG=$(date +%s)" >> $GITHUB_ENV
 
       - name: Docker Metadata action
         id: meta
@@ -26,8 +24,6 @@ jobs:
           tags: |
             type=sha
             beta
-          labels: |
-            VERSION="${{ github.event.inputs.DOCKER_TAG }}"
 
       - name: Docker Setup QEMU
         uses: docker/setup-qemu-action@v2.1.0

--- a/.github/workflows/docker-beta.yml
+++ b/.github/workflows/docker-beta.yml
@@ -8,13 +8,15 @@ env:
   APP_NAME: watchlistarr
   DOCKER_FILE: docker/Dockerfile
   DOCKER_PLATFORMS: "linux/arm64/v8,linux/amd64"
-  DOCKER_TAG: $(date +%s)
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Set up environment
+        run: echo "DOCKER_TAG=$(date +%s)" >> $GITHUB_ENV
+
 
       - name: Docker Setup QEMU
         uses: docker/setup-qemu-action@v2.1.0
@@ -37,5 +39,5 @@ jobs:
           file: ${{ env.DOCKER_FILE }}
           platforms: ${{ env.DOCKER_PLATFORMS }}
           push: true
-          tags: ${{env.DOCKER_TAG}},beta
-          labels: VERSION=${{env.DOCKER_TAG}}
+          tags: ${{ github.event.inputs.DOCKER_TAG }},beta
+          labels: VERSION="${{ github.event.inputs.DOCKER_TAG }}"

--- a/.github/workflows/docker-beta.yml
+++ b/.github/workflows/docker-beta.yml
@@ -24,7 +24,7 @@ jobs:
           images: |
             ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.APP_NAME }}
           tags: |
-            ${{ github.event.inputs.DOCKER_TAG }}
+            type=sha
             beta
           labels: |
             VERSION="${{ github.event.inputs.DOCKER_TAG }}"

--- a/.github/workflows/docker-beta.yml
+++ b/.github/workflows/docker-beta.yml
@@ -38,7 +38,7 @@ jobs:
           buildkitd-flags: --debug
 
       - name: Login to DockerHub
-        uses: docker/login-action@v2.1.0
+        uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/docker-beta.yml
+++ b/.github/workflows/docker-beta.yml
@@ -4,26 +4,40 @@ on:
   push:
     branches: [ "main" ]
 
+env:
+  APP_NAME: watchlistarr
+  DOCKER_FILE: docker/Dockerfile
+  DOCKER_PLATFORMS: "linux/arm64/v8,linux/amd64"
+
 jobs:
-
   build:
-
     runs-on: ubuntu-latest
-
-
     steps:
       - uses: actions/checkout@v3
       - name: Set up environment
         run: echo "DOCKER_TAG=$(date +%s)" >> $GITHUB_ENV
+
+
+      - name: Docker Setup QEMU
+        uses: docker/setup-qemu-action@v2.1.0
+    
+      - name: Docker Setup Buildx
+        uses: docker/setup-buildx-action@v2.5.0
+        with:
+          buildkitd-flags: --debug
+
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2.1.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build the Docker image
-        run: docker build . --file docker/Dockerfile --tag nylonee/watchlistarr:${DOCKER_TAG} --label=VERSION=${DOCKER_TAG}
-      - name: Push Docker image
-        run: |
-          docker tag nylonee/watchlistarr:${DOCKER_TAG} nylonee/watchlistarr:beta
-          docker push nylonee/watchlistarr:${DOCKER_TAG}
-          docker push nylonee/watchlistarr:beta
+
+      - name: Build and push Docker images
+        uses: docker/build-push-action@v4.0.0
+        with:
+          context: .
+          file: ${{ env.DOCKER_FILE }}
+          platforms: ${{ env.DOCKER_PLATFORMS }}
+          push: true
+          tags: ${DOCKER_TAG},beta
+          labels: VERSION=${DOCKER_TAG}

--- a/.github/workflows/docker-beta.yml
+++ b/.github/workflows/docker-beta.yml
@@ -15,6 +15,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Docker Metadata action
         id: meta
         uses: docker/metadata-action@v4.3.0
@@ -32,12 +38,6 @@ jobs:
         uses: docker/setup-buildx-action@v2.5.0
         with:
           buildkitd-flags: --debug
-
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push Docker images
         uses: docker/build-push-action@v4.0.0

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -9,6 +9,7 @@ env:
   DOCKER_FILE: docker/Dockerfile
   DOCKER_PLATFORMS: "linux/arm64/v8,linux/amd64"
 
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -17,6 +18,17 @@ jobs:
       - name: Set up environment
         run: echo "DOCKER_TAG=$(date +%s)" >> $GITHUB_ENV
 
+      - name: Docker Metadata action
+        id: meta
+        uses: docker/metadata-action@v4.3.0
+        with:
+          images: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.APP_NAME }}
+          tags: |
+            ${{ github.event.inputs.DOCKER_TAG }}
+            latest
+          labels: |
+            VERSION="${{ github.event.inputs.DOCKER_TAG }}"
 
       - name: Docker Setup QEMU
         uses: docker/setup-qemu-action@v2.1.0
@@ -39,5 +51,5 @@ jobs:
           file: ${{ env.DOCKER_FILE }}
           platforms: ${{ env.DOCKER_PLATFORMS }}
           push: true
-          tags: ${DOCKER_TAG},latest
-          labels: VERSION=${DOCKER_TAG}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -40,7 +40,7 @@ jobs:
           buildkitd-flags: --debug
 
       - name: Login to DockerHub
-        uses: docker/login-action@v2.1.0
+        uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -4,25 +4,40 @@ on:
   release:
     types: [published]
 
+env:
+  APP_NAME: watchlistarr
+  DOCKER_FILE: docker/Dockerfile
+  DOCKER_PLATFORMS: "linux/arm64/v8,linux/amd64"
+
 jobs:
-
   build:
-
     runs-on: ubuntu-latest
-
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up environment
-        run: echo "DOCKER_TAG=${{ github.event.release.tag_name }}" >> $GITHUB_ENV
+        run: echo "DOCKER_TAG=$(date +%s)" >> $GITHUB_ENV
+
+
+      - name: Docker Setup QEMU
+        uses: docker/setup-qemu-action@v2.1.0
+    
+      - name: Docker Setup Buildx
+        uses: docker/setup-buildx-action@v2.5.0
+        with:
+          buildkitd-flags: --debug
+
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2.1.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build the Docker image
-        run: docker build . --file docker/Dockerfile --tag nylonee/watchlistarr:${DOCKER_TAG} --label=VERSION=${DOCKER_TAG}
-      - name: Push Docker image
-        run: |
-          docker tag nylonee/watchlistarr:${DOCKER_TAG} nylonee/watchlistarr:latest
-          docker push nylonee/watchlistarr:${DOCKER_TAG}
-          docker push nylonee/watchlistarr:latest
+
+      - name: Build and push Docker images
+        uses: docker/build-push-action@v4.0.0
+        with:
+          context: .
+          file: ${{ env.DOCKER_FILE }}
+          platforms: ${{ env.DOCKER_PLATFORMS }}
+          push: true
+          tags: ${DOCKER_TAG},latest
+          labels: VERSION=${DOCKER_TAG}

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -16,6 +16,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Docker Metadata action
         id: meta
         uses: docker/metadata-action@v4.3.0
@@ -34,12 +41,6 @@ jobs:
         uses: docker/setup-buildx-action@v2.5.0
         with:
           buildkitd-flags: --debug
-
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push Docker images
         uses: docker/build-push-action@v4.0.0

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -25,7 +25,8 @@ jobs:
           images: |
             ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.APP_NAME }}
           tags: |
-            ${{ github.event.inputs.DOCKER_TAG }}
+            type=sha
+            type=semver,pattern={{version}}
             latest
           labels: |
             VERSION="${{ github.event.inputs.DOCKER_TAG }}"

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -15,8 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up environment
-        run: echo "DOCKER_TAG=$(date +%s)" >> $GITHUB_ENV
 
       - name: Docker Metadata action
         id: meta
@@ -28,8 +26,6 @@ jobs:
             type=sha
             type=semver,pattern={{version}}
             latest
-          labels: |
-            VERSION="${{ github.event.inputs.DOCKER_TAG }}"
 
       - name: Docker Setup QEMU
         uses: docker/setup-qemu-action@v2.1.0


### PR DESCRIPTION
## Description
Adding support for ARM64 releases.

Breaking changes:
Earlier we were using date to tag docker releases.
I have used sha for the same. Rest all remains same.

## Checklist
- [ ] Documentation Updated
- [ ] `sbt scalafmtAll` Run (and optionally `sbt scalafmtSbt`)
- [ ] At least one approval from a codeowner


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved Docker build workflows to enhance the build process and deployment of Docker images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->