### PR TITLE
Add support for ARM64

### DIFF
--- a/.github/workflows/docker-alpha.yml
+++ b/.github/workflows/docker-alpha.yml
@@ -1,7 +1,7 @@
 name: Update Docker alpha tag
 
 on:
-  pull_request:
+  push:
     branches: [actions-merge-preview/**]
 
 env:

--- a/.github/workflows/docker-alpha.yml
+++ b/.github/workflows/docker-alpha.yml
@@ -4,26 +4,48 @@ on:
   pull_request:
     branches: [ "main" ]
 
+env:
+  APP_NAME: watchlistarr
+  DOCKER_FILE: docker/Dockerfile
+  DOCKER_PLATFORMS: "linux/arm64/v8,linux/amd64"
+
+
 jobs:
-
   build:
-
     runs-on: ubuntu-latest
-
-
     steps:
       - uses: actions/checkout@v3
-      - name: Set up environment
-        run: echo "DOCKER_TAG=$(date +%s)" >> $GITHUB_ENV
+
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build the Docker image
-        run: docker build . --file docker/Dockerfile --tag nylonee/watchlistarr:${DOCKER_TAG} --label=VERSION=${DOCKER_TAG}
-      - name: Push Docker image
-        run: |
-          docker tag nylonee/watchlistarr:${DOCKER_TAG} nylonee/watchlistarr:alpha
-          docker push nylonee/watchlistarr:${DOCKER_TAG}
-          docker push nylonee/watchlistarr:alpha
+
+      - name: Docker Metadata action
+        id: meta
+        uses: docker/metadata-action@v4.3.0
+        with:
+          images: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.APP_NAME }}
+          tags: |
+            type=sha
+            alpha
+
+      - name: Docker Setup QEMU
+        uses: docker/setup-qemu-action@v2.1.0
+    
+      - name: Docker Setup Buildx
+        uses: docker/setup-buildx-action@v2.5.0
+        with:
+          buildkitd-flags: --debug
+
+      - name: Build and push Docker images
+        uses: docker/build-push-action@v4.0.0
+        with:
+          context: .
+          file: ${{ env.DOCKER_FILE }}
+          platforms: ${{ env.DOCKER_PLATFORMS }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-alpha.yml
+++ b/.github/workflows/docker-alpha.yml
@@ -1,7 +1,7 @@
 name: Update Docker alpha tag
 
 on:
-  pull_request:
+  push:
     branches: ["actions-merge-preview/**"]
 
 env:

--- a/.github/workflows/docker-alpha.yml
+++ b/.github/workflows/docker-alpha.yml
@@ -1,7 +1,7 @@
 name: Update Docker alpha tag
 
 on:
-  push:
+  pull_request:
     branches: ["actions-merge-preview/**"]
 
 env:

--- a/.github/workflows/docker-alpha.yml
+++ b/.github/workflows/docker-alpha.yml
@@ -2,7 +2,7 @@ name: Update Docker alpha tag
 
 on:
   pull_request:
-    branches: [ "main" ]
+    branches: [actions-merge-preview/**]
 
 env:
   APP_NAME: watchlistarr

--- a/.github/workflows/docker-alpha.yml
+++ b/.github/workflows/docker-alpha.yml
@@ -2,7 +2,7 @@ name: Update Docker alpha tag
 
 on:
   push:
-    branches: [actions-merge-preview/**]
+    branches: ["actions-merge-preview/**"]
 
 env:
   APP_NAME: watchlistarr

--- a/.github/workflows/docker-beta.yml
+++ b/.github/workflows/docker-beta.yml
@@ -4,26 +4,47 @@ on:
   push:
     branches: [ "main" ]
 
+env:
+  APP_NAME: watchlistarr
+  DOCKER_FILE: docker/Dockerfile
+  DOCKER_PLATFORMS: "linux/arm64/v8,linux/amd64"
+
 jobs:
-
   build:
-
     runs-on: ubuntu-latest
-
-
     steps:
       - uses: actions/checkout@v3
-      - name: Set up environment
-        run: echo "DOCKER_TAG=$(date +%s)" >> $GITHUB_ENV
+
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build the Docker image
-        run: docker build . --file docker/Dockerfile --tag nylonee/watchlistarr:${DOCKER_TAG} --label=VERSION=${DOCKER_TAG}
-      - name: Push Docker image
-        run: |
-          docker tag nylonee/watchlistarr:${DOCKER_TAG} nylonee/watchlistarr:beta
-          docker push nylonee/watchlistarr:${DOCKER_TAG}
-          docker push nylonee/watchlistarr:beta
+
+      - name: Docker Metadata action
+        id: meta
+        uses: docker/metadata-action@v4.3.0
+        with:
+          images: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.APP_NAME }}
+          tags: |
+            type=sha
+            beta
+
+      - name: Docker Setup QEMU
+        uses: docker/setup-qemu-action@v2.1.0
+    
+      - name: Docker Setup Buildx
+        uses: docker/setup-buildx-action@v2.5.0
+        with:
+          buildkitd-flags: --debug
+
+      - name: Build and push Docker images
+        uses: docker/build-push-action@v4.0.0
+        with:
+          context: .
+          file: ${{ env.DOCKER_FILE }}
+          platforms: ${{ env.DOCKER_PLATFORMS }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/merge-preview.yml
+++ b/.github/workflows/merge-preview.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   preview:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - uses: nwtgck/actions-merge-preview@develop

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -4,25 +4,50 @@ on:
   release:
     types: [published]
 
+env:
+  APP_NAME: watchlistarr
+  DOCKER_FILE: docker/Dockerfile
+  DOCKER_PLATFORMS: "linux/arm64/v8,linux/amd64"
+
+
 jobs:
-
   build:
-
     runs-on: ubuntu-latest
-
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up environment
-        run: echo "DOCKER_TAG=${{ github.event.release.tag_name }}" >> $GITHUB_ENV
+      - uses: actions/checkout@v3
+
+
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build the Docker image
-        run: docker build . --file docker/Dockerfile --tag nylonee/watchlistarr:${DOCKER_TAG} --label=VERSION=${DOCKER_TAG}
-      - name: Push Docker image
-        run: |
-          docker tag nylonee/watchlistarr:${DOCKER_TAG} nylonee/watchlistarr:latest
-          docker push nylonee/watchlistarr:${DOCKER_TAG}
-          docker push nylonee/watchlistarr:latest
+
+      - name: Docker Metadata action
+        id: meta
+        uses: docker/metadata-action@v4.3.0
+        with:
+          images: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.APP_NAME }}
+          tags: |
+            type=sha
+            type=semver,pattern={{version}}
+            latest
+
+      - name: Docker Setup QEMU
+        uses: docker/setup-qemu-action@v2.1.0
+    
+      - name: Docker Setup Buildx
+        uses: docker/setup-buildx-action@v2.5.0
+        with:
+          buildkitd-flags: --debug
+
+      - name: Build and push Docker images
+        uses: docker/build-push-action@v4.0.0
+        with:
+          context: .
+          file: ${{ env.DOCKER_FILE }}
+          platforms: ${{ env.DOCKER_PLATFORMS }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Description
Adding support for ARM64 releases.

Breaking changes:
Earlier we were using date to tag docker releases.
I have used sha for the same. Rest all remains same.

## Checklist
- [ ] Documentation Updated
- [ ] `sbt scalafmtAll` Run (and optionally `sbt scalafmtSbt`)
- [ ] At least one approval from a codeowner


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Updated Docker workflows in `.github/workflows/docker-alpha.yml` and `.github/workflows/docker-beta.yml` to include changes in branch triggering, environment variables, Docker image building, and pushing steps.
  - Changed the operating system from `ubuntu-18.04` to `ubuntu-latest` in `.github/workflows/merge-preview.yml`.
  - Updated job configuration in `.github/workflows/release-docker.yml` for building and pushing Docker images with specific platforms and tags.

- **Enhancements**
  - Improved Docker workflows for better handling of metadata, environment variables, and specific tags and labels.
  - Enhanced CI/CD pipelines with new steps for Docker image creation, including QEMU and Buildx setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->