### PR TITLE
use new ubuntu version

### DIFF
--- a/.github/workflows/merge-preview.yml
+++ b/.github/workflows/merge-preview.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   preview:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - uses: nwtgck/actions-merge-preview@develop


### PR DESCRIPTION
## Description
Github doesn't support old ubuntu version.

## Checklist
- [ ] Documentation Updated
- [ ] `sbt scalafmtAll` Run (and optionally `sbt scalafmtSbt`)
- [ ] At least one approval from a codeowner
