### PR TITLE
Fix: Use PAT so that next workflows can be triggered.

### DIFF
--- a/.github/workflows/merge-preview.yml
+++ b/.github/workflows/merge-preview.yml
@@ -7,9 +7,12 @@ on:
 
 jobs:
   preview:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
+      # https://github.com/orgs/community/discussions/25702
     - uses: actions/checkout@v2
+      with:
+        token: ${{ secrets.PAT_TOKEN }}
     - uses: nwtgck/actions-merge-preview@develop
       with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
+        github-token: ${{ secrets.PAT_TOKEN }}


### PR DESCRIPTION
## Description

## WHY
So there were two issues with the older update
1. I used ubuntu 18, Github CI stopped supporting that. i.e updatating to using latest.
2. When a action is triggered by using GITHUB_TOKEN. it wouldn't trigger subsequent workflows.
https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs
The workaround suggested is to use a PAT. Earlier there were security concerns but now. it's safer as we have fine-grained personal access token.

## How to use
![image](https://github.com/nylonee/watchlistarr/assets/22419015/735798ca-65ff-477f-86c5-8c3ab1f01491)

```sh
@bee-bot merge preview
```
## Who can run
Only USERS or Collaborators would be able to run https://github.com/nwtgck/actions-merge-preview/blob/develop/src/main.ts#L25


## How to setup PAT (with minimal access):
1. https://github.com/settings/tokens
![image](https://github.com/nylonee/watchlistarr/assets/22419015/12857b73-ec45-4ba3-9503-6d28da56b45f)

2. select repo
![image](https://github.com/nylonee/watchlistarr/assets/22419015/bf2793da-0dee-4e8a-9042-024161656c50)
3. add these permission to token
![image](https://github.com/nylonee/watchlistarr/assets/22419015/59e10e9d-191f-4d3c-8a6a-c5c3b07aacc5)
4. Add token to your repository settings.


Tested & Working: https://github.com/ankit16-19/watchlistarr/pull/15

## Checklist
- [ ] Documentation Updated
- [ ] `sbt scalafmtAll` Run (and optionally `sbt scalafmtSbt`)
- [ ] At least one approval from a codeowner


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the system's underlying infrastructure to enhance performance and security.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->