### PR TITLE
Use new API endpoint for `importexclusionlist`

### DIFF
--- a/src/main/scala/sonarr/SonarrSeries.scala
+++ b/src/main/scala/sonarr/SonarrSeries.scala
@@ -7,3 +7,12 @@ private[sonarr] case class SonarrSeries(
     id: Long,
     ended: Option[Boolean]
 )
+
+private[sonarr] case class SonarrPagedSeries(
+    page: Int,
+    pageSize: Int,
+    sortKey: String,
+    sortDirection: String,
+    totalRecords: Int,
+    records: List[SonarrSeries]
+)


### PR DESCRIPTION
## Description
Using the deprecated API endpoint was causing warning logs, so I added some new code in to use the new API endpoint in Sonarr

## Checklist
- [ ] Documentation Updated
- [X] `sbt scalafmtAll` Run (and optionally `sbt scalafmtSbt`)
- [ ] At least one approval from a codeowner
