### PR TITLE
Allow configuration for choosing to delete files

### DIFF
--- a/src/main/resources/config-template.yaml
+++ b/src/main/resources/config-template.yaml
@@ -91,3 +91,6 @@
 
 ## Number of days to wait before deleting content from the arrs (Deleting must be enabled). DEFAULT: 7
 #  interval.days: 7
+
+## Choose whether you want to delete the files as well, or only the entry in Sonarr/Radarr. DEFAULT: true
+#  deleteFiles: true

--- a/src/main/scala/PlexTokenDeleteSync.scala
+++ b/src/main/scala/PlexTokenDeleteSync.scala
@@ -69,7 +69,7 @@ object PlexTokenDeleteSync extends PlexUtils with SonarrUtils with RadarrUtils {
 
   private def deleteMovie(client: HttpClient, config: Configuration)(movie: Item): EitherT[IO, Throwable, Unit] =
     if (config.deleteConfiguration.movieDeleting) {
-      deleteFromRadarr(client, config.radarrConfiguration)(movie)
+      deleteFromRadarr(client, config.radarrConfiguration, config.deleteConfiguration.deleteFiles)(movie)
     } else {
       logger.info(s"Found movie \"${movie.title}\" which is not watchlisted on Plex")
       EitherT.pure[IO, Throwable](())
@@ -77,9 +77,9 @@ object PlexTokenDeleteSync extends PlexUtils with SonarrUtils with RadarrUtils {
 
   private def deleteSeries(client: HttpClient, config: Configuration)(show: Item): EitherT[IO, Throwable, Unit] =
     if (show.ended.contains(true) && config.deleteConfiguration.endedShowDeleting) {
-      deleteFromSonarr(client, config.sonarrConfiguration)(show)
+      deleteFromSonarr(client, config.sonarrConfiguration, config.deleteConfiguration.deleteFiles)(show)
     } else if (show.ended.contains(false) && config.deleteConfiguration.continuingShowDeleting) {
-      deleteFromSonarr(client, config.sonarrConfiguration)(show)
+      deleteFromSonarr(client, config.sonarrConfiguration, config.deleteConfiguration.deleteFiles)(show)
     } else {
       logger.info(s"Found show \"${show.title}\" which is not watchlisted on Plex")
       EitherT[IO, Throwable, Unit](IO.pure(Right(())))

--- a/src/main/scala/configuration/Configuration.scala
+++ b/src/main/scala/configuration/Configuration.scala
@@ -43,5 +43,6 @@ case class DeleteConfiguration(
     movieDeleting: Boolean,
     endedShowDeleting: Boolean,
     continuingShowDeleting: Boolean,
-    deleteInterval: FiniteDuration
+    deleteInterval: FiniteDuration,
+    deleteFiles: Boolean
 )

--- a/src/main/scala/configuration/ConfigurationRedactor.scala
+++ b/src/main/scala/configuration/ConfigurationRedactor.scala
@@ -34,6 +34,7 @@ object ConfigurationRedactor {
       |    endedShowDeleting: ${config.deleteConfiguration.endedShowDeleting}
       |    continuingShowDeleting: ${config.deleteConfiguration.continuingShowDeleting}
       |    deleteInterval: ${config.deleteConfiguration.deleteInterval.toDays} days
+      |    deleteFiles: ${config.deleteConfiguration.deleteFiles}
       |
       |""".stripMargin
 }

--- a/src/main/scala/configuration/ConfigurationUtils.scala
+++ b/src/main/scala/configuration/ConfigurationUtils.scala
@@ -46,7 +46,7 @@ object ConfigurationUtils {
         .flatMap(_.toBooleanOption)
         .getOrElse(false)
       deleteInterval = configReader.getConfigOption(Keys.deleteIntervalDays).flatMap(_.toIntOption).getOrElse(7).days
-      deleteFiles = configReader.getConfigOption(Keys.deleteFiles).flatMap(_.toBooleanOption).getOrElse(true)
+      deleteFiles    = configReader.getConfigOption(Keys.deleteFiles).flatMap(_.toBooleanOption).getOrElse(true)
       hasPlexPass    = plexWatchlistUrls.nonEmpty
     } yield Configuration(
       if (hasPlexPass) refreshInterval else 19.minutes,

--- a/src/main/scala/configuration/ConfigurationUtils.scala
+++ b/src/main/scala/configuration/ConfigurationUtils.scala
@@ -46,6 +46,7 @@ object ConfigurationUtils {
         .flatMap(_.toBooleanOption)
         .getOrElse(false)
       deleteInterval = configReader.getConfigOption(Keys.deleteIntervalDays).flatMap(_.toIntOption).getOrElse(7).days
+      deleteFiles = configReader.getConfigOption(Keys.deleteFiles).flatMap(_.toBooleanOption).getOrElse(true)
       hasPlexPass    = plexWatchlistUrls.nonEmpty
     } yield Configuration(
       if (hasPlexPass) refreshInterval else 19.minutes,
@@ -77,7 +78,8 @@ object ConfigurationUtils {
         deleteMovies,
         deleteEndedShows,
         deleteContinuingShows,
-        deleteInterval
+        deleteInterval,
+        deleteFiles
       )
     )
 

--- a/src/main/scala/configuration/Keys.scala
+++ b/src/main/scala/configuration/Keys.scala
@@ -27,4 +27,5 @@ private[configuration] object Keys {
   val deleteMovies         = "delete.movie"
   val deleteEndedShow      = "delete.endedShow"
   val deleteContinuingShow = "delete.continuingShow"
+  val deleteFiles          = "delete.deleteFiles"
 }

--- a/src/main/scala/radarr/RadarrUtils.scala
+++ b/src/main/scala/radarr/RadarrUtils.scala
@@ -50,7 +50,7 @@ trait RadarrUtils extends RadarrConversions {
     }
   }
 
-  protected def deleteFromRadarr(client: HttpClient, config: RadarrConfiguration)(
+  protected def deleteFromRadarr(client: HttpClient, config: RadarrConfiguration, deleteFiles: Boolean)(
       item: Item
   ): EitherT[IO, Throwable, Unit] = {
     val movieId = item.getRadarrId.getOrElse {
@@ -58,7 +58,7 @@ trait RadarrUtils extends RadarrConversions {
       0L
     }
 
-    deleteToArr(client)(config.radarrBaseUrl, config.radarrApiKey, movieId)
+    deleteToArr(client)(config.radarrBaseUrl, config.radarrApiKey, movieId, deleteFiles)
       .map { r =>
         logger.info(s"Deleted ${item.title} from Radarr")
         r
@@ -85,9 +85,9 @@ trait RadarrUtils extends RadarrConversions {
       decoded <- EitherT.fromOption[IO](maybeDecoded.toOption, new Throwable("Unable to decode response from Radarr"))
     } yield decoded
 
-  private def deleteToArr(client: HttpClient)(baseUrl: Uri, apiKey: String, id: Long): EitherT[IO, Throwable, Unit] = {
+  private def deleteToArr(client: HttpClient)(baseUrl: Uri, apiKey: String, id: Long, deleteFiles: Boolean): EitherT[IO, Throwable, Unit] = {
     val urlWithQueryParams = (baseUrl / "api" / "v3" / "movie" / id)
-      .withQueryParam("deleteFiles", true)
+      .withQueryParam("deleteFiles", deleteFiles)
       .withQueryParam("addImportExclusion", false)
 
     EitherT(client.httpRequest(Method.DELETE, urlWithQueryParams, Some(apiKey)))

--- a/src/main/scala/radarr/RadarrUtils.scala
+++ b/src/main/scala/radarr/RadarrUtils.scala
@@ -85,7 +85,9 @@ trait RadarrUtils extends RadarrConversions {
       decoded <- EitherT.fromOption[IO](maybeDecoded.toOption, new Throwable("Unable to decode response from Radarr"))
     } yield decoded
 
-  private def deleteToArr(client: HttpClient)(baseUrl: Uri, apiKey: String, id: Long, deleteFiles: Boolean): EitherT[IO, Throwable, Unit] = {
+  private def deleteToArr(
+      client: HttpClient
+  )(baseUrl: Uri, apiKey: String, id: Long, deleteFiles: Boolean): EitherT[IO, Throwable, Unit] = {
     val urlWithQueryParams = (baseUrl / "api" / "v3" / "movie" / id)
       .withQueryParam("deleteFiles", deleteFiles)
       .withQueryParam("addImportExclusion", false)

--- a/src/main/scala/sonarr/SonarrUtils.scala
+++ b/src/main/scala/sonarr/SonarrUtils.scala
@@ -53,7 +53,7 @@ trait SonarrUtils extends SonarrConversions {
     }
   }
 
-  protected def deleteFromSonarr(client: HttpClient, config: SonarrConfiguration)(
+  protected def deleteFromSonarr(client: HttpClient, config: SonarrConfiguration, deleteFiles: Boolean)(
       item: Item
   ): EitherT[IO, Throwable, Unit] = {
     val showId = item.getSonarrId.getOrElse {
@@ -61,16 +61,16 @@ trait SonarrUtils extends SonarrConversions {
       0L
     }
 
-    deleteToArr(client)(config.sonarrBaseUrl, config.sonarrApiKey, showId)
+    deleteToArr(client)(config.sonarrBaseUrl, config.sonarrApiKey, showId, deleteFiles)
       .map { r =>
         logger.info(s"Deleted ${item.title} from Sonarr")
         r
       }
   }
 
-  private def deleteToArr(client: HttpClient)(baseUrl: Uri, apiKey: String, id: Long): EitherT[IO, Throwable, Unit] = {
+  private def deleteToArr(client: HttpClient)(baseUrl: Uri, apiKey: String, id: Long, deleteFiles: Boolean): EitherT[IO, Throwable, Unit] = {
     val urlWithQueryParams = (baseUrl / "api" / "v3" / "series" / id)
-      .withQueryParam("deleteFiles", true)
+      .withQueryParam("deleteFiles", deleteFiles)
       .withQueryParam("addImportListExclusion", false)
 
     EitherT(client.httpRequest(Method.DELETE, urlWithQueryParams, Some(apiKey)))

--- a/src/main/scala/sonarr/SonarrUtils.scala
+++ b/src/main/scala/sonarr/SonarrUtils.scala
@@ -68,7 +68,9 @@ trait SonarrUtils extends SonarrConversions {
       }
   }
 
-  private def deleteToArr(client: HttpClient)(baseUrl: Uri, apiKey: String, id: Long, deleteFiles: Boolean): EitherT[IO, Throwable, Unit] = {
+  private def deleteToArr(
+      client: HttpClient
+  )(baseUrl: Uri, apiKey: String, id: Long, deleteFiles: Boolean): EitherT[IO, Throwable, Unit] = {
     val urlWithQueryParams = (baseUrl / "api" / "v3" / "series" / id)
       .withQueryParam("deleteFiles", deleteFiles)
       .withQueryParam("addImportListExclusion", false)

--- a/src/test/scala/PlexTokenSyncSpec.scala
+++ b/src/test/scala/PlexTokenSyncSpec.scala
@@ -60,7 +60,8 @@ class PlexTokenSyncSpec extends AnyFlatSpec with Matchers with MockFactory {
       movieDeleting = false,
       endedShowDeleting = false,
       continuingShowDeleting = false,
-      deleteInterval = 7.days
+      deleteInterval = 7.days,
+      deleteFiles = true
     )
   )
 

--- a/src/test/scala/configuration/ConfigurationUtilsSpec.scala
+++ b/src/test/scala/configuration/ConfigurationUtilsSpec.scala
@@ -203,6 +203,7 @@ class ConfigurationUtilsSpec extends AnyFlatSpec with Matchers with MockFactory 
     (mockConfigReader.getConfigOption _).expects(Keys.deleteIntervalDays).returning(unset).anyNumberOfTimes()
     (mockConfigReader.getConfigOption _).expects(Keys.sonarrTags).returning(tags).anyNumberOfTimes()
     (mockConfigReader.getConfigOption _).expects(Keys.radarrTags).returning(tags).anyNumberOfTimes()
+    (mockConfigReader.getConfigOption _).expects(Keys.deleteFiles).returning(unset).anyNumberOfTimes()
     mockConfigReader
   }
 


### PR DESCRIPTION
## Description
Configuration to allow choosing whether files should be deleted off the system, or just the content from the Sonarr/Radarr database

## Checklist
- [ ] Documentation Updated
- [ ] `sbt scalafmtAll` Run (and optionally `sbt scalafmtSbt`)
- [ ] At least one approval from a codeowner
