### PR TITLE
Add random UUID to bypass cache

### DIFF
--- a/src/main/scala/plex/PlexUtils.scala
+++ b/src/main/scala/plex/PlexUtils.scala
@@ -13,6 +13,8 @@ import io.circe.generic.extras.auto._
 import io.circe.syntax.EncoderOps
 import org.http4s.client.UnexpectedStatus
 
+import java.util.UUID
+
 trait PlexUtils {
 
   private val logger = LoggerFactory.getLogger(getClass)
@@ -21,7 +23,10 @@ trait PlexUtils {
     extras.Configuration.default.withDefaults
 
   protected def fetchWatchlistFromRss(client: HttpClient)(url: Uri): IO[Set[Item]] = {
-    val jsonFormatUrl = url.withQueryParam("format", "json")
+    val randomUUID = UUID.randomUUID().toString.take(5)
+    val jsonFormatUrl = url
+      .withQueryParam("format", "json")
+      .withQueryParam(randomUUID, randomUUID)
 
     client.httpRequest(Method.GET, jsonFormatUrl).map {
       case Left(UnexpectedStatus(s, _, _)) if s.code == 500 =>


### PR DESCRIPTION
## Description
Bypass the cache by providing a random parameter during watchlist fetching

## Checklist
- [ ] Documentation Updated
- [ ] `sbt scalafmtAll` Run (and optionally `sbt scalafmtSbt`)
- [ ] At least one approval from a codeowner
