### PR TITLE
Deprecated api remove

### DIFF
--- a/src/main/scala/sonarr/SonarrUtils.scala
+++ b/src/main/scala/sonarr/SonarrUtils.scala
@@ -24,7 +24,7 @@ trait SonarrUtils extends SonarrConversions {
         if (bypass) {
           EitherT.pure[IO, Throwable](List.empty[SonarrSeries])
         } else {
-          getToArr[List[SonarrSeries]](client)(baseUrl, apiKey, "importlistexclusion")
+          getToArr[List[SonarrSeries]](client)(baseUrl, apiKey, "importlistexclusion/paged", Map("pageSize" -> "-1"))
         }
     } yield (shows.map(toItem) ++ exclusions.map(toItem)).toSet
 
@@ -82,12 +82,16 @@ trait SonarrUtils extends SonarrConversions {
 
   private def getToArr[T: Decoder](
       client: HttpClient
-  )(baseUrl: Uri, apiKey: String, endpoint: String): EitherT[IO, Throwable, T] =
+  )(baseUrl: Uri, apiKey: String, endpoint: String, params: Map[String, Any] = Map.empty): EitherT[IO, Throwable, T] = {
+    val urlWithParams = params.foldLeft(baseUrl / "api" / "v3" / endpoint) {
+      case (url, (key, value)) => url.withQueryParam(key, value.toString)
+    }
     for {
-      response     <- EitherT(client.httpRequest(Method.GET, baseUrl / "api" / "v3" / endpoint, Some(apiKey)))
+      response     <- EitherT(client.httpRequest(Method.GET, urlWithParams, Some(apiKey)))
       maybeDecoded <- EitherT.pure[IO, Throwable](response.as[T])
-      decoded <- EitherT.fromOption[IO](maybeDecoded.toOption, new Throwable("Unable to decode response from Sonarr"))
+      decoded <- EitherT.fromOption[IO](maybeDecoded.toOption, new Throwable("Unable to decode response from Radarr"))
     } yield decoded
+  }
 
   private def postToArr[T: Decoder](
       client: HttpClient

--- a/src/main/scala/sonarr/SonarrUtils.scala
+++ b/src/main/scala/sonarr/SonarrUtils.scala
@@ -89,7 +89,7 @@ trait SonarrUtils extends SonarrConversions {
     for {
       response     <- EitherT(client.httpRequest(Method.GET, urlWithParams, Some(apiKey)))
       maybeDecoded <- EitherT.pure[IO, Throwable](response.as[T])
-      decoded <- EitherT.fromOption[IO](maybeDecoded.toOption, new Throwable("Unable to decode response from Radarr"))
+      decoded <- EitherT.fromOption[IO](maybeDecoded.toOption, new Throwable("Unable to decode response from Sonarr"))
     } yield decoded
   }
 


### PR DESCRIPTION
## Description
I've updated work with *arr to non deprecated api

## Checklist
- [ ] Documentation Updated
- [ ] `sbt scalafmtAll` Run (and optionally `sbt scalafmtSbt`)
- [ ] At least one approval from a codeowner


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced flexibility in fetching movie and series exclusions with the addition of dynamic query parameters.
  - Updated endpoints for fetching exclusions to improve data retrieval.

- **Bug Fixes**
  - Improved error messaging for response decoding to provide clearer context.

- **Documentation**
  - Updated method signatures to reflect the inclusion of query parameters in relevant functions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->