### PR TITLE
Draft: Add support to keep a Radarr item that contains a specific tag

### DIFF
--- a/src/main/resources/config-template.yaml
+++ b/src/main/resources/config-template.yaml
@@ -61,6 +61,9 @@
 #  tags:
 #    - watchlistarr
 
+## Tag to use in Radarr to bypass movie deletion
+#  skipTag: "keep"
+
 
 #################################################################
 ## Plex Configuration

--- a/src/main/scala/configuration/Configuration.scala
+++ b/src/main/scala/configuration/Configuration.scala
@@ -29,7 +29,8 @@ case class RadarrConfiguration(
     radarrQualityProfileId: Int,
     radarrRootFolder: String,
     radarrBypassIgnored: Boolean,
-    radarrTagIds: Set[Int]
+    radarrTagIds: Set[Int],
+    radarrSkipTag: String
 )
 
 case class PlexConfiguration(

--- a/src/main/scala/configuration/ConfigurationRedactor.scala
+++ b/src/main/scala/configuration/ConfigurationRedactor.scala
@@ -22,6 +22,7 @@ object ConfigurationRedactor {
       |    radarrRootFolder: ${config.radarrConfiguration.radarrRootFolder}
       |    radarrBypassIgnored: ${config.radarrConfiguration.radarrBypassIgnored}
       |    radarrTagIds: ${config.radarrConfiguration.radarrTagIds.mkString(",")}
+      |    radarrSkipTag: ${config.radarrConfiguration.radarrSkipTag}
       |
       |  PlexConfiguration:
       |    plexWatchlistUrls: ${config.plexConfiguration.plexWatchlistUrls.mkString(", ")}

--- a/src/main/scala/configuration/Keys.scala
+++ b/src/main/scala/configuration/Keys.scala
@@ -17,6 +17,7 @@ private[configuration] object Keys {
   val radarrRootFolder     = "radarr.rootFolder"
   val radarrBypassIgnored  = "radarr.bypassIgnored"
   val radarrTags           = "radarr.tags"
+  val radarrSkipTag        = "radarr.skipTag"
 
   val plexWatchlist1 = "plex.watchlist1"
   val plexWatchlist2 = "plex.watchlist2"

--- a/src/main/scala/radarr/RadarrConversions.scala
+++ b/src/main/scala/radarr/RadarrConversions.scala
@@ -11,6 +11,6 @@ private[radarr] trait RadarrConversions {
   )
 
   def toItem(movie: RadarrMovieExclusion): Item = toItem(
-    RadarrMovie(movie.movieTitle, movie.imdbId, movie.tmdbId, movie.id)
+    RadarrMovie(movie.movieTitle, movie.imdbId, movie.tmdbId, movie.id, List.empty)
   )
 }

--- a/src/main/scala/radarr/RadarrMovie.scala
+++ b/src/main/scala/radarr/RadarrMovie.scala
@@ -1,3 +1,3 @@
 package radarr
 
-private[radarr] case class RadarrMovie(title: String, imdbId: Option[String], tmdbId: Option[Long], id: Long)
+private[radarr] case class RadarrMovie(title: String, imdbId: Option[String], tmdbId: Option[Long], id: Long, tags: List[Int])

--- a/src/main/scala/radarr/RadarrTag.scala
+++ b/src/main/scala/radarr/RadarrTag.scala
@@ -1,0 +1,3 @@
+package radarr
+
+private[radarr] case class RadarrTag(label: String, id: Int)

--- a/src/test/scala/PlexTokenSyncSpec.scala
+++ b/src/test/scala/PlexTokenSyncSpec.scala
@@ -48,7 +48,8 @@ class PlexTokenSyncSpec extends AnyFlatSpec with Matchers with MockFactory {
       radarrQualityProfileId = 1,
       radarrRootFolder = "/root/",
       radarrBypassIgnored = false,
-      radarrTagIds = Set(2)
+      radarrTagIds = Set(2),
+      "keep"
     ),
     PlexConfiguration(
       plexWatchlistUrls = Set(),


### PR DESCRIPTION
## Description
Add support to configure a tag that, if such tag is added to the Radarr item, Watchlistarr will skip and not delete that entry from Radarr when the associated movie is removed from Plex Watchlist.

## Checklist
- [ ] Documentation Updated
- [ ] `sbt scalafmtAll` Run (and optionally `sbt scalafmtSbt`)
- [ ] At least one approval from a codeowner
