### PR TITLE
Fix: Refactor HttpClient to prevent potential memory leak

### DIFF
--- a/src/main/scala/Server.scala
+++ b/src/main/scala/Server.scala
@@ -24,7 +24,7 @@ object Server extends IOApp {
     val httpClientResource = EmberClientBuilder.default[IO].build.map(FollowRedirect(5))
 
     httpClientResource.use { implicit resolvedHttpClient: Client[IO] =>
-      val appHttpClient = new HttpClient(resolvedHttpClient)
+      val appHttpClient = new http.HttpClient(resolvedHttpClient)
       for {
         initialConfig <- ConfigurationUtils.create(configReader, appHttpClient)
         configRef     <- Ref.of[IO, Configuration](initialConfig)

--- a/src/main/scala/Server.scala
+++ b/src/main/scala/Server.scala
@@ -24,6 +24,7 @@ object Server extends IOApp {
     val httpClientResource = EmberClientBuilder.default[IO].build.map(FollowRedirect(5))
 
     httpClientResource.use { implicit resolvedHttpClient: Client[IO] =>
+
       val appHttpClient = new http.HttpClient(resolvedHttpClient)
       for {
         initialConfig <- ConfigurationUtils.create(configReader, appHttpClient)

--- a/src/main/scala/http/HttpClient.scala
+++ b/src/main/scala/http/HttpClient.scala
@@ -10,11 +10,10 @@ import org.http4s.{Header, Method, Request, Uri}
 import org.typelevel.ci.CIString
 import com.github.blemale.scaffeine.{AsyncLoadingCache, Scaffeine}
 import org.slf4j.LoggerFactory
-
 import scala.concurrent.duration._
-import org.http4s.client.Client
+import org.http4s.client.Client // This import is fine, but the class signature will use FQN
 
-class HttpClient(httpClient: Client[IO]) {
+class HttpClient(httpClient: org.http4s.client.Client[IO]) {
 
   private val logger = LoggerFactory.getLogger(getClass)
 

--- a/src/main/scala/http/HttpClient.scala
+++ b/src/main/scala/http/HttpClient.scala
@@ -12,15 +12,11 @@ import com.github.blemale.scaffeine.{AsyncLoadingCache, Scaffeine}
 import org.slf4j.LoggerFactory
 
 import scala.concurrent.duration._
+import org.http4s.client.Client
 
-class HttpClient {
+class HttpClient(httpClient: Client[IO]) {
 
   private val logger = LoggerFactory.getLogger(getClass)
-
-  private val client = EmberClientBuilder
-    .default[IO]
-    .build
-    .map(FollowRedirect(5))
 
   private val cacheTtl = 5.seconds
 
@@ -66,7 +62,7 @@ class HttpClient {
 
     logger.debug(s"HTTP Request: ${requestWithPayload.toString()}")
 
-    val responseIO = client.use(_.expect[Json](requestWithPayload).attempt)
+    val responseIO = httpClient.expect[Json](requestWithPayload).attempt
 
     responseIO.map { response =>
       logger.debug(s"HTTP Response: $response")

--- a/src/test/scala/http/HttpClientSpec.scala
+++ b/src/test/scala/http/HttpClientSpec.scala
@@ -11,11 +11,11 @@ import org.http4s.dsl.io._
 import org.http4s.ember.client.EmberClientBuilder
 import org.http4s.ember.server.EmberServerBuilder
 import org.http4s.server.Server
-import org.scalatest.matchers.should.Matchers
-import org.scalatest.wordspec.AsyncWordSpec
-import cats.effect.testing.scalatest.AsyncIOSpec // Ensure this is the correct one
+// import org.scalatest.wordspec.AsyncWordSpec // No longer needed
+import cats.effect.testing.scalatest.AsyncIOSpec
+import org.scalatest.matchers.should.Matchers // Ensure Matchers is imported and used
 
-class HttpClientSpec extends AsyncWordSpec with AsyncIOSpec with Matchers {
+class HttpClientSpec extends AsyncIOSpec with Matchers {
 
   // Define the service for the test server
   val testService: HttpRoutes[IO] = HttpRoutes.of[IO] {
@@ -57,13 +57,13 @@ class HttpClientSpec extends AsyncWordSpec with AsyncIOSpec with Matchers {
 
         resultsIO.asserting { results =>
           results.foreach { result =>
-            result shouldBe a[Right[_, _]]
+            result shouldBe a[Right[_, _]] // Uses Matchers
             result.foreach { json =>
-              json.hcursor.downField("message").as[String] shouldBe Right("Ok")
+              json.hcursor.downField("message").as[String] shouldBe Right("Ok") // Uses Matchers
             }
           }
-          results.length shouldBe numRequests
-          results.count(_.isRight) shouldBe numRequests
+          results.length shouldBe numRequests // Uses Matchers
+          results.count(_.isRight) shouldBe numRequests // Uses Matchers
         }
       }
     }

--- a/src/test/scala/http/HttpClientSpec.scala
+++ b/src/test/scala/http/HttpClientSpec.scala
@@ -1,0 +1,71 @@
+package http
+
+import cats.effect.{IO, Resource}
+import cats.syntax.all._
+import com.comcast.ip4s._
+import io.circe.Json
+import org.http4s._
+import org.http4s.circe._
+import org.http4s.client.Client
+import org.http4s.dsl.io._
+import org.http4s.ember.client.EmberClientBuilder
+import org.http4s.ember.server.EmberServerBuilder
+import org.http4s.server.Server
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AsyncWordSpec
+import cats.effect.testing.scalatest.AsyncIOSpec // Ensure this is the correct one
+
+class HttpClientSpec extends AsyncWordSpec with AsyncIOSpec with Matchers {
+
+  // Define the service for the test server
+  val testService: HttpRoutes[IO] = HttpRoutes.of[IO] {
+    case GET -> Root / "test" / id =>
+      Ok(Json.obj("id" -> Json.fromString(id), "message" -> Json.fromString("Ok")))
+  }
+
+  // Resource for the test server
+  val serverResource: Resource[IO, Server] = EmberServerBuilder
+    .default[IO]
+    .withHost(ipv4"0.0.0.0")
+    .withPort(port"0") // Use port 0 to let the system pick an available port
+    .withHttpApp(testService.orNotFound)
+    .build
+
+  // Resource for the http4s client
+  val clientResource: Resource[IO, Client[IO]] = EmberClientBuilder
+    .default[IO]
+    .build
+
+  "HttpClient" should {
+    "stress test HttpClient with multiple requests" in {
+      val numRequests = 500
+      val uniqueRequests = numRequests / 2
+
+      (serverResource, clientResource).tupled.use { case (server, liveHttpClient) =>
+        val httpClient = new HttpClient(liveHttpClient) // Use the live client from the resource
+
+        val baseUri = s"http://${server.address.getHostString}:${server.address.getPort}/test"
+
+        // Generate 250 unique URIs and 250 duplicates
+        val uris = (0 until uniqueRequests).map(i => Uri.unsafeFromString(s"$baseUri/$i")).toList ++
+                   (0 until uniqueRequests).map(i => Uri.unsafeFromString(s"$baseUri/$i")).toList
+
+        uris.length shouldBe numRequests // Quick check
+
+        val resultsIO: IO[List[Either[Throwable, Json]]] =
+          Traverse[List].traverse(uris)(uri => httpClient.httpRequest(Method.GET, uri))
+
+        resultsIO.asserting { results =>
+          results.foreach { result =>
+            result shouldBe a[Right[_, _]]
+            result.foreach { json =>
+              json.hcursor.downField("message").as[String] shouldBe Right("Ok")
+            }
+          }
+          results.length shouldBe numRequests
+          results.count(_.isRight) shouldBe numRequests
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
The previous implementation of HttpClient created and managed its own http4s EmberClientBuilder instance, using `client.use` within the `makeHttpRequest` method. This method's result (an IO wrapped in a Future) was cached. This meant that each request, even a cached one, could potentially re-evaluate or re-trigger aspects of the client resource management, leading to inefficient resource use and a high risk of memory leaks due to constant, fine-grained acquire/release cycles of the HTTP client resources.

This commit refactors the HttpClient and Server:

1.  `HttpClient` now accepts an `org.http4s.client.Client[IO]` as a constructor parameter. It no longer builds its own client.
2.  `Server.scala` now creates a single `EmberClientBuilder` resource at application startup and passes the resolved `Client[IO]` to the `HttpClient`. This ensures the HTTP client's lifecycle is tied to the application's lifecycle, which is the standard and recommended practice.
3.  Added `HttpClientSpec.scala` with a stress test that makes numerous requests to an embedded server. This test helps verify the stability of `HttpClient` under load with the new resource management strategy.

These changes should resolve the suspected memory leak by ensuring proper and efficient management of HTTP client resources.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added a new stress test suite for the HTTP client to ensure reliability under high request loads.

- **Refactor**
  - Improved HTTP client management with resource-safe handling and redirect support.
  - Updated method signatures and client usage for consistency and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->