### PR TITLE
fix: update Plex watchlist URL

### DIFF
--- a/src/main/scala/plex/PlexUtils.scala
+++ b/src/main/scala/plex/PlexUtils.scala
@@ -71,7 +71,7 @@ trait PlexUtils {
     .map { token =>
       val containerSize = 300
       val url = Uri
-        .unsafeFromString("https://metadata.provider.plex.tv/library/sections/watchlist/all")
+        .unsafeFromString("https://discover.provider.plex.tv/library/sections/watchlist/all")
         .withQueryParam("X-Plex-Token", token)
         .withQueryParam("X-Plex-Container-Start", containerStart)
         .withQueryParam("X-Plex-Container-Size", containerSize)

--- a/src/test/scala/PlexTokenSyncSpec.scala
+++ b/src/test/scala/PlexTokenSyncSpec.scala
@@ -70,7 +70,7 @@ class PlexTokenSyncSpec extends AnyFlatSpec with Matchers with MockFactory {
       .expects(
         Method.GET,
         Uri.unsafeFromString(
-          "https://metadata.provider.plex.tv/library/sections/watchlist/all?X-Plex-Token=plex-token&X-Plex-Container-Start=0&X-Plex-Container-Size=300"
+          "https://discover.provider.plex.tv/library/sections/watchlist/all?X-Plex-Token=plex-token&X-Plex-Container-Start=0&X-Plex-Container-Size=300"
         ),
         None,
         None

--- a/src/test/scala/plex/PlexUtilsSpec.scala
+++ b/src/test/scala/plex/PlexUtilsSpec.scala
@@ -79,7 +79,7 @@ class PlexUtilsSpec extends AnyFlatSpec with Matchers with PlexUtils with MockFa
       .expects(
         Method.GET,
         Uri.unsafeFromString(
-          "https://metadata.provider.plex.tv/library/sections/watchlist/all?X-Plex-Token=test-token&X-Plex-Container-Start=0&X-Plex-Container-Size=300"
+          "https://discover.provider.plex.tv/library/sections/watchlist/all?X-Plex-Token=test-token&X-Plex-Container-Start=0&X-Plex-Container-Size=300"
         ),
         None,
         None
@@ -124,7 +124,7 @@ class PlexUtilsSpec extends AnyFlatSpec with Matchers with PlexUtils with MockFa
       .expects(
         Method.GET,
         Uri.unsafeFromString(
-          "https://metadata.provider.plex.tv/library/sections/watchlist/all?X-Plex-Token=test-token&X-Plex-Container-Start=0&X-Plex-Container-Size=300"
+          "https://discover.provider.plex.tv/library/sections/watchlist/all?X-Plex-Token=test-token&X-Plex-Container-Start=0&X-Plex-Container-Size=300"
         ),
         None,
         None
@@ -146,7 +146,7 @@ class PlexUtilsSpec extends AnyFlatSpec with Matchers with PlexUtils with MockFa
       .expects(
         Method.GET,
         Uri.unsafeFromString(
-          "https://metadata.provider.plex.tv/library/sections/watchlist/all?X-Plex-Token=test-token&X-Plex-Container-Start=0&X-Plex-Container-Size=300"
+          "https://discover.provider.plex.tv/library/sections/watchlist/all?X-Plex-Token=test-token&X-Plex-Container-Start=0&X-Plex-Container-Size=300"
         ),
         None,
         None


### PR DESCRIPTION
## Description
This PR updates the Plex watchlist base URL to the new endpoint, replacing the deprecated one.

## Checklist
- [ ] Documentation Updated
- [ ] `sbt scalafmtAll` Run (and optionally `sbt scalafmtSbt`)
- [ ] At least one approval from a codeowner


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - Updated Plex watchlist fetching to use the Discover endpoint, improving reliability of watchlist sync without altering parameters or paging behavior.

- Tests
  - Adjusted test expectations to match the new Discover watchlist endpoint; test logic and scenarios remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->