### PR TITLE
fix(plex): switch Watchlist base URL to discover.provider.plex.tv

### DIFF
--- a/src/main/scala/plex/PlexUtils.scala
+++ b/src/main/scala/plex/PlexUtils.scala
@@ -71,7 +71,7 @@ trait PlexUtils {
     .map { token =>
       val containerSize = 300
       val url = Uri
-        .unsafeFromString("https://metadata.provider.plex.tv/library/sections/watchlist/all")
+        .unsafeFromString("https://discover.provider.plex.tv/library/sections/watchlist/all")
         .withQueryParam("X-Plex-Token", token)
         .withQueryParam("X-Plex-Container-Start", containerStart)
         .withQueryParam("X-Plex-Container-Size", containerSize)

--- a/src/test/scala/PlexTokenSyncSpec.scala
+++ b/src/test/scala/PlexTokenSyncSpec.scala
@@ -70,7 +70,7 @@ class PlexTokenSyncSpec extends AnyFlatSpec with Matchers with MockFactory {
       .expects(
         Method.GET,
         Uri.unsafeFromString(
-          "https://metadata.provider.plex.tv/library/sections/watchlist/all?X-Plex-Token=plex-token&X-Plex-Container-Start=0&X-Plex-Container-Size=300"
+          "https://discover.provider.plex.tv/library/sections/watchlist/all?X-Plex-Token=plex-token&X-Plex-Container-Start=0&X-Plex-Container-Size=300"
         ),
         None,
         None

--- a/src/test/scala/plex/PlexUtilsSpec.scala
+++ b/src/test/scala/plex/PlexUtilsSpec.scala
@@ -79,7 +79,7 @@ class PlexUtilsSpec extends AnyFlatSpec with Matchers with PlexUtils with MockFa
       .expects(
         Method.GET,
         Uri.unsafeFromString(
-          "https://metadata.provider.plex.tv/library/sections/watchlist/all?X-Plex-Token=test-token&X-Plex-Container-Start=0&X-Plex-Container-Size=300"
+          "https://discover.provider.plex.tv/library/sections/watchlist/all?X-Plex-Token=test-token&X-Plex-Container-Start=0&X-Plex-Container-Size=300"
         ),
         None,
         None
@@ -124,7 +124,7 @@ class PlexUtilsSpec extends AnyFlatSpec with Matchers with PlexUtils with MockFa
       .expects(
         Method.GET,
         Uri.unsafeFromString(
-          "https://metadata.provider.plex.tv/library/sections/watchlist/all?X-Plex-Token=test-token&X-Plex-Container-Start=0&X-Plex-Container-Size=300"
+          "https://discover.provider.plex.tv/library/sections/watchlist/all?X-Plex-Token=test-token&X-Plex-Container-Start=0&X-Plex-Container-Size=300"
         ),
         None,
         None
@@ -146,7 +146,7 @@ class PlexUtilsSpec extends AnyFlatSpec with Matchers with PlexUtils with MockFa
       .expects(
         Method.GET,
         Uri.unsafeFromString(
-          "https://metadata.provider.plex.tv/library/sections/watchlist/all?X-Plex-Token=test-token&X-Plex-Container-Start=0&X-Plex-Container-Size=300"
+          "https://discover.provider.plex.tv/library/sections/watchlist/all?X-Plex-Token=test-token&X-Plex-Container-Start=0&X-Plex-Container-Size=300"
         ),
         None,
         None


### PR DESCRIPTION
Plex moved Watchlist endpoints from metadata.* to discover.*.
The old Watchlist URL returns 404; this updates the Watchlist base URL and adjusts tests.

- Old: https://metadata.provider.plex.tv/library/sections/watchlist/...
- New: https://discover.provider.plex.tv/library/sections/watchlist/...

Only Watchlist is changed in this PR (scrobble/userstate left untouched).
Manually verified with a container built from this commit: requests succeed (200/304) using discover.*.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Updated Plex watchlist retrieval to use the Discover service endpoint, improving reliability and compatibility of watchlist syncing without changing user settings or workflows.
- Tests
  - Adjusted test cases to reflect the new watchlist endpoint, preserving existing coverage and scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->