### PR TITLE
Update Docker base image to eclipse-temurin:21-alpine

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,15 +5,16 @@ WORKDIR /app
 COPY . .
 
 RUN sbt update compile stage
-RUN chmod a+rx /app/target/universal/stage/bin/*
 
-FROM openjdk:11-jre-slim
+FROM eclipse-temurin:21-alpine
 
 WORKDIR /app
+RUN apk add --no-cache bash
 
 COPY --from=build /app/target/universal/stage /app
 
-COPY --chmod=755 docker/entrypoint.sh /app/entrypoint.sh
-RUN sed -i 's/\r$//' /app/entrypoint.sh
+COPY docker/entrypoint.sh /app/entrypoint.sh
 
-ENTRYPOINT ["/app/entrypoint.sh"]
+RUN chmod +x /app/entrypoint.sh && sed -i 's/\r$//' /app/entrypoint.sh
+
+ENTRYPOINT ["/bin/bash", "/app/entrypoint.sh"]


### PR DESCRIPTION
Replace deprecated openjdk image with modern eclipse-temurin. Add bash and fix entrypoint script to resolve container startup issues.

## Description
Enter a meaningful description here of the changes, including any relevant links

## Checklist
- [ ] Documentation Updated
- [ ] `sbt scalafmtAll` Run (and optionally `sbt scalafmtSbt`)
- [ ] At least one approval from a codeowner


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Java runtime from version 11 to version 21.
  * Upgraded container base image to Alpine for improved efficiency and reduced size.
  * Enhanced container startup script handling for improved reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->