### PR TITLE
fix: Update Plex requests

### DIFF
--- a/src/main/resources/config-template.yaml
+++ b/src/main/resources/config-template.yaml
@@ -2,10 +2,10 @@
 ## Uncomment the lines you would like to configure, then save this file and restart Watchlistarr
 
 #interval:
-## How often do you want Watchlistarr to pull the latest from Plex? In general, 10-30 seconds is okay.
+## How often do you want Watchlistarr to pull the latest from Plex? In general, 60-300 seconds is okay.
 ## If you're running this on a slower system (e.g. Raspberry Pi), you may want to increase this
 ## Note: If you do not have Plex Pass, this will be overridden to ~19 minute syncs, see README
-#  seconds: 10
+#  seconds: 120
 
 
 #################################################################

--- a/src/main/scala/configuration/ConfigurationUtils.scala
+++ b/src/main/scala/configuration/ConfigurationUtils.scala
@@ -28,7 +28,7 @@ object ConfigurationUtils {
   def create(configReader: ConfigurationReader, client: HttpClient): IO[Configuration] = {
     val config = for {
       sonarrConfig <- getSonarrConfig(configReader, client)
-      refreshInterval = configReader.getConfigOption(Keys.intervalSeconds).flatMap(_.toIntOption).getOrElse(60).seconds
+      refreshInterval = configReader.getConfigOption(Keys.intervalSeconds).flatMap(_.toIntOption).getOrElse(120).seconds
       (sonarrBaseUrl, sonarrApiKey, sonarrQualityProfileId, sonarrRootFolder, sonarrLanguageProfileId, sonarrTagIds) =
         sonarrConfig
       sonarrBypassIgnored    = configReader.getConfigOption(Keys.sonarrBypassIgnored).exists(_.toBoolean)


### PR DESCRIPTION
## Description

- Updated the `interval.seconds` to `120` in the config template
- Updated the RSS interval to be randomly selected between `refreshInterval` & `4 * refreshInterval`
- Removed the `cache_buster` parameter (has no effect anymore - prevents a 302 redirect)
- Reduce the container size parameter to `100`
- Add random delays during pagination requests

PS: The code was edited using an AI agent. Please point out any mistakes.

## Checklist
- [ ] Documentation Updated
- [ ] `sbt scalafmtAll` Run (and optionally `sbt scalafmtSbt`)
- [ ] At least one approval from a codeowner


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Increased default polling interval for Plex synchronization from 10 to 120 seconds
  * Added randomized jitter to synchronization operations for improved server stability
  * Refined data retrieval paging parameters for more conservative resource usage

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->