### PR TITLE
Add radarr.availability config option and startup version logging

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,14 @@ ThisBuild / scalaVersion := "2.13.12"
 lazy val root = (project in file("."))
   .settings(
     name                 := "watchlistarr",
-    assembly / mainClass := Some("Server")
+    version              := "0.2.7",
+    assembly / mainClass := Some("Server"),
+    Compile / resourceGenerators += Def.task {
+      val file = (Compile / resourceManaged).value / "version.properties"
+      val content = s"version=${version.value}\n"
+      IO.write(file, content)
+      Seq(file)
+    }.taskValue
   )
 
 val caseInsensitiveVersion    = "1.4.0"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,13 +1,18 @@
-FROM hseeberger/scala-sbt:eclipse-temurin-11.0.14.1_1.6.2_2.13.8 as build
+FROM hseeberger/scala-sbt:eclipse-temurin-11.0.14.1_1.6.2_2.13.8 AS build
 
 WORKDIR /app
 
+# Copy project definition first for caching
+COPY project ./project
+COPY build.sbt ./
+
+# Copy the rest of the source code
 COPY . .
 
 RUN sbt update compile stage
 RUN chmod a+rx /app/target/universal/stage/bin/*
 
-FROM openjdk:11-jre-slim
+FROM eclipse-temurin:11-jre-jammy
 
 WORKDIR /app
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -35,6 +35,10 @@ if [ -n "$RADARR_ROOT_FOLDER" ]; then
   CMD+=("-Dradarr.rootFolder=$RADARR_ROOT_FOLDER")
 fi
 
+if [ -n "$RADARR_AVAILABILITY" ]; then
+  CMD+=("-Dradarr.availability=$RADARR_AVAILABILITY")
+fi
+
 if [ -n "$PLEX_WATCHLIST_URL_1" ]; then
   CMD+=("-Dplex.watchlist1=$PLEX_WATCHLIST_URL_1")
 fi

--- a/src/main/scala/Server.scala
+++ b/src/main/scala/Server.scala
@@ -20,7 +20,18 @@ object Server extends IOApp {
     val configReader = FileAndSystemPropertyReader
     val httpClient   = new HttpClient
 
+    val version = IO {
+      val props = new java.util.Properties()
+      val stream = getClass.getClassLoader.getResourceAsStream("version.properties")
+      if (stream != null) {
+        try props.load(stream) finally stream.close()
+      }
+      props.getProperty("version", "unknown")
+    }
+
     for {
+      v             <- version
+      _             <- IO(logger.info(s"watchlistarr v$v starting"))
       initialConfig <- ConfigurationUtils.create(configReader, httpClient)
       configRef     <- Ref.of[IO, Configuration](initialConfig)
       result <- (

--- a/src/main/scala/configuration/Configuration.scala
+++ b/src/main/scala/configuration/Configuration.scala
@@ -27,6 +27,7 @@ case class RadarrConfiguration(
     radarrBaseUrl: Uri,
     radarrApiKey: String,
     radarrQualityProfileId: Int,
+    radarrAvailability: Option[String],
     radarrRootFolder: String,
     radarrBypassIgnored: Boolean,
     radarrTagIds: Set[Int]

--- a/src/main/scala/configuration/ConfigurationRedactor.scala
+++ b/src/main/scala/configuration/ConfigurationRedactor.scala
@@ -21,6 +21,7 @@ object ConfigurationRedactor {
       |    radarrQualityProfileId: ${config.radarrConfiguration.radarrQualityProfileId}
       |    radarrRootFolder: ${config.radarrConfiguration.radarrRootFolder}
       |    radarrBypassIgnored: ${config.radarrConfiguration.radarrBypassIgnored}
+      |    radarrAvailability: ${config.radarrConfiguration.radarrAvailability.getOrElse("not set")}
       |    radarrTagIds: ${config.radarrConfiguration.radarrTagIds.mkString(",")}
       |
       |  PlexConfiguration:

--- a/src/main/scala/configuration/ConfigurationUtils.scala
+++ b/src/main/scala/configuration/ConfigurationUtils.scala
@@ -188,7 +188,7 @@ object ConfigurationUtils {
         .getConfigOption(Keys.radarrTags)
         .map(getTagIdsFromConfig(client, url, apiKey))
         .getOrElse(IO.pure(Set.empty[Int]))
-      availability = configReader.getConfigOption(Keys.radarrAvailability)
+      availability = configReader.getConfigOption(Keys.radarrAvailability).map(_.trim).filter(_.nonEmpty)
     } yield (url, apiKey, qualityProfileId, rootFolder, tagIds, availability)
   }
 

--- a/src/main/scala/configuration/ConfigurationUtils.scala
+++ b/src/main/scala/configuration/ConfigurationUtils.scala
@@ -34,7 +34,7 @@ object ConfigurationUtils {
       sonarrBypassIgnored    = configReader.getConfigOption(Keys.sonarrBypassIgnored).exists(_.toBoolean)
       sonarrSeasonMonitoring = configReader.getConfigOption(Keys.sonarrSeasonMonitoring).getOrElse("all")
       radarrConfig <- getRadarrConfig(configReader, client)
-      (radarrBaseUrl, radarrApiKey, radarrQualityProfileId, radarrRootFolder, radarrTagIds) = radarrConfig
+      (radarrBaseUrl, radarrApiKey, radarrQualityProfileId, radarrRootFolder, radarrTagIds, radarrAvailability) = radarrConfig
       radarrBypassIgnored = configReader.getConfigOption(Keys.radarrBypassIgnored).exists(_.toBoolean)
       plexTokens          = getPlexTokens(configReader)
       skipFriendSync = configReader.getConfigOption(Keys.skipFriendSync).flatMap(_.toBooleanOption).getOrElse(false)
@@ -64,6 +64,7 @@ object ConfigurationUtils {
         radarrBaseUrl,
         radarrApiKey,
         radarrQualityProfileId,
+        radarrAvailability,
         radarrRootFolder,
         radarrBypassIgnored,
         radarrTagIds
@@ -159,7 +160,7 @@ object ConfigurationUtils {
   private def getRadarrConfig(
       configReader: ConfigurationReader,
       client: HttpClient
-  ): IO[(Uri, String, Int, String, Set[Int])] = {
+  ): IO[(Uri, String, Int, String, Set[Int], Option[String])] = {
     val apiKey = configReader.getConfigOption(Keys.radarrApiKey).getOrElse(throwError("Unable to find radarr API key"))
     val configuredUrl = configReader.getConfigOption(Keys.radarrBaseUrl)
     val possibleUrls: Seq[String] =
@@ -187,7 +188,8 @@ object ConfigurationUtils {
         .getConfigOption(Keys.radarrTags)
         .map(getTagIdsFromConfig(client, url, apiKey))
         .getOrElse(IO.pure(Set.empty[Int]))
-    } yield (url, apiKey, qualityProfileId, rootFolder, tagIds)
+      availability = configReader.getConfigOption(Keys.radarrAvailability)
+    } yield (url, apiKey, qualityProfileId, rootFolder, tagIds, availability)
   }
 
   private def getTagIdsFromConfig(client: HttpClient, url: Uri, apiKey: String)(tags: String): IO[Set[Int]] = {

--- a/src/main/scala/configuration/Keys.scala
+++ b/src/main/scala/configuration/Keys.scala
@@ -14,6 +14,7 @@ private[configuration] object Keys {
   val radarrBaseUrl        = "radarr.baseUrl"
   val radarrApiKey         = "radarr.apikey"
   val radarrQualityProfile = "radarr.qualityProfile"
+  val radarrAvailability   = "radarr.availability"
   val radarrRootFolder     = "radarr.rootFolder"
   val radarrBypassIgnored  = "radarr.bypassIgnored"
   val radarrTags           = "radarr.tags"

--- a/src/main/scala/http/HttpClient.scala
+++ b/src/main/scala/http/HttpClient.scala
@@ -52,8 +52,7 @@ class HttpClient {
       .withHeaders(
         Header.Raw(CIString("Accept"), "application/json"),
         Header.Raw(CIString("Content-Type"), "application/json"),
-        Header.Raw(CIString("User-Agent"), "watchlistarr/1.0"),
-        Header.Raw(CIString("Host"), host)
+        Header.Raw(CIString("User-Agent"), "watchlistarr/1.0")
       )
     val requestWithApiKey = apiKey.fold(baseRequest)(key =>
       baseRequest.withHeaders(

--- a/src/main/scala/radarr/RadarrPost.scala
+++ b/src/main/scala/radarr/RadarrPost.scala
@@ -1,10 +1,29 @@
 package radarr
 
-private case class RadarrPost(
+import io.circe.syntax._
+import io.circe.{Encoder, Json, JsonObject}
+
+case class RadarrPost(
     title: String,
     tmdbId: Long,
     qualityProfileId: Int = 6,
     rootFolderPath: String,
-    addOptions: AddOptions = AddOptions(),
+    minimumAvailability: Option[String] = None,
     tags: List[Int] = List.empty[Int]
 )
+
+object RadarrPost {
+  implicit val encoder: Encoder[RadarrPost] = Encoder.instance { post =>
+    var fields = List[(String, Json)](
+      "title"            -> post.title.asJson,
+      "tmdbId"           -> post.tmdbId.asJson,
+      "qualityProfileId" -> post.qualityProfileId.asJson,
+      "rootFolderPath"   -> post.rootFolderPath.asJson,
+      "tags"             -> post.tags.asJson
+    )
+    post.minimumAvailability.foreach { avail =>
+      fields = fields :+ ("minimumAvailability" -> avail.asJson)
+    }
+    Json.fromJsonObject(JsonObject.fromIterable(fields))
+  }
+}

--- a/src/main/scala/radarr/RadarrUtils.scala
+++ b/src/main/scala/radarr/RadarrUtils.scala
@@ -35,6 +35,7 @@ trait RadarrUtils extends RadarrConversions {
       item.getTmdbId.getOrElse(0L),
       config.radarrQualityProfileId,
       config.radarrRootFolder,
+      minimumAvailability = config.radarrAvailability,
       tags = config.radarrTagIds.toList
     )
 


### PR DESCRIPTION
Adds RADARR_AVAILABILITY env var to control movie availability in Radarr.
When set (e.g. RADARR_AVAILABILITY=announced), the minimumAvailability
field is included in the POST payload to /api/v3/movie. Omitted when
not set to avoid null serialization.

Also adds startup version log.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for configuring a minimum availability when adding movies to Radarr
  * Application logs its version on startup

* **Chores**
  * Docker base image updated to eclipse-temurin:11-jre-jammy and build caching improved
  * Entrypoint can pass RADARR availability to the app when set
  * Removed unnecessary Host header from outgoing HTTP requests
<!-- end of auto-generated comment: release notes by coderabbit.ai -->